### PR TITLE
Fix GitHub token persistence

### DIFF
--- a/apps/api/src/auth/auth.service.ts
+++ b/apps/api/src/auth/auth.service.ts
@@ -33,13 +33,16 @@ export class AuthService {
     if (!user) {
       user = this.usersService.create(profile, githubAccessToken);
     } else {
-      const updatedUser = this.usersService.update(user.id, {
+      const updateData: Partial<User> = {
         username: profile.username,
         email: profile.emails?.[0]?.value || user.email,
         avatarUrl: profile.photos?.[0]?.value || user.avatarUrl,
         name: profile.displayName || profile.username || user.name,
-        githubAccessToken,
-      });
+      };
+      if (githubAccessToken) {
+        updateData.githubAccessToken = githubAccessToken;
+      }
+      const updatedUser = this.usersService.update(user.id, updateData);
       if (!updatedUser) {
         throw new Error('Failed to update user');
       }


### PR DESCRIPTION
## Summary
- keep stored GitHub access token when OAuth callback does not include one

## Testing
- `npx -y turbo run lint` *(fails: cannot find ESLint modules)*
- `npm run test` in `apps/api` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686acead98448320bea4de09929e1b20