### PR TITLE
Handle GitHub App installation events

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,12 +5,12 @@ en posts LinkedIn prêts à publier.
 
 ## Monorepo
 
-| Path        | Stack                          | Rôle                                 |
-|-------------|--------------------------------|--------------------------------------|
-| apps/web    | Next 15, Tailwind, shadcn/ui   | Interface utilisateur                |
-| apps/api    | NestJS 10, Prisma, Redis       | API REST + Webhooks GitHub           |
-| apps/docs   | Next static export             | Documentation publique               |
-| packages/\* | Core logic, UI, configs        | Code partagé                        |
+| Path        | Stack                        | Rôle                       |
+| ----------- | ---------------------------- | -------------------------- |
+| apps/web    | Next 15, Tailwind, shadcn/ui | Interface utilisateur      |
+| apps/api    | NestJS 10, Prisma, Redis     | API REST + Webhooks GitHub |
+| apps/docs   | Next static export           | Documentation publique     |
+| packages/\* | Core logic, UI, configs      | Code partagé               |
 
 ## Démarrage rapide
 
@@ -18,11 +18,18 @@ en posts LinkedIn prêts à publier.
 npm install        # à la racine
 npm run dev:web    # lance le front
 npm run dev:api    # lance l'API NestJS
+npm --workspace=api run tunnel # expose l'API via localtunnel
 ```
+
+### Tester les webhooks GitHub
+
+Configurez l'URL `https://<sous-domaine>.loca.lt/webhooks/github` dans les
+paramètres de votre GitHub App puis installez l'app depuis le dashboard.
 
 ## Architecture
 
 ### Frontend (apps/web)
+
 - **Next.js 15** avec App Router et React Server Components
 - **Tailwind CSS v4** pour le styling
 - **shadcn/ui** pour les composants
@@ -32,6 +39,7 @@ npm run dev:api    # lance l'API NestJS
 - **Framer Motion** pour les animations
 
 ### Backend (apps/api)
+
 - **NestJS 10** avec TypeScript strict
 - **Prisma** avec PostgreSQL
 - **Redis** pour le cache et les queues
@@ -40,6 +48,7 @@ npm run dev:api    # lance l'API NestJS
 - **BullMQ** pour les tâches asynchrones
 
 ### Base de données
+
 ```sql
 -- Schéma Prisma (à développer)
 model User {
@@ -81,7 +90,8 @@ npm run format      # Format avec Prettier
 ### Variables d'environnement
 
 **apps/api/.env**
-```bash
+
+````bash
 # Database
 DATABASE_URL="postgresql://user:password@localhost:5432/quori"
 
@@ -101,12 +111,12 @@ OPENAI_API_KEY="sk-..."
 NEXT_PUBLIC_API_URL="http://localhost:3001"
 NEXTAUTH_URL="http://localhost:3000"
 NEXTAUTH_SECRET="your_nextauth_secret"
-```
+````
 
 ## Workflow de développement
 
 1. **Webhook GitHub** reçoit push/PR → parse les changements
-2. **Queue BullMQ** traite les événements de manière asynchrone  
+2. **Queue BullMQ** traite les événements de manière asynchrone
 3. **OpenAI GPT-4** génère le post LinkedIn en français
 4. **Frontend** affiche les posts avec options d'édition
 5. **Utilisateur** copie/colle ou publie directement
@@ -114,25 +124,29 @@ NEXTAUTH_SECRET="your_nextauth_secret"
 ## Roadmap (30 jours)
 
 ### Week 1: Foundation
+
 - [x] Setup monorepo with Turbo
 - [x] NestJS API with Prisma
 - [x] Next.js frontend with Tailwind
 - [ ] GitHub webhook endpoint
 - [ ] Basic authentication
 
-### Week 2: Core Features  
+### Week 2: Core Features
+
 - [ ] Git event parsing logic
 - [ ] OpenAI integration for post generation
 - [ ] Basic UI for post management
 - [ ] Redis queues for async processing
 
 ### Week 3: Polish
+
 - [ ] Post editing interface
 - [ ] LinkedIn formatting preview
 - [ ] Error handling & monitoring
 - [ ] Basic analytics
 
 ### Week 4: Launch
+
 - [ ] Stripe integration (freemium model)
 - [ ] Production deployment
 - [ ] Documentation complète
@@ -163,6 +177,7 @@ npm run dev:web    # Terminal 2
 ## Tech Stack
 
 ### Frontend
+
 - **Framework**: Next.js 15 (App Router)
 - **Styling**: Tailwind CSS v4
 - **Components**: shadcn/ui, Radix UI
@@ -171,7 +186,8 @@ npm run dev:web    # Terminal 2
 - **Animation**: Framer Motion
 - **Auth**: NextAuth.js (future)
 
-### Backend  
+### Backend
+
 - **Framework**: NestJS 10
 - **Database**: PostgreSQL + Prisma
 - **Cache**: Redis + BullMQ
@@ -180,9 +196,10 @@ npm run dev:web    # Terminal 2
 - **Validation**: class-validator
 
 ### DevOps
+
 - **Monorepo**: Turborepo
 - **Package Manager**: npm workspaces
-- **Linting**: ESLint + Prettier  
+- **Linting**: ESLint + Prettier
 - **Git Hooks**: Husky + lint-staged
 - **CI/CD**: GitHub Actions
 - **Deployment**: Vercel (frontend) + Railway (backend)

--- a/apps/api/migrations/001-initial.sql
+++ b/apps/api/migrations/001-initial.sql
@@ -1,0 +1,28 @@
+-- installations
+CREATE TABLE IF NOT EXISTS installations (
+  installation_id bigint PRIMARY KEY,
+  account_login text,
+  account_id bigint,
+  repos text[],
+  created_at timestamptz DEFAULT now()
+);
+
+-- events
+CREATE TABLE IF NOT EXISTS events (
+  delivery_id text PRIMARY KEY,
+  installation_id bigint REFERENCES installations(installation_id),
+  event text,
+  payload jsonb,
+  received_at timestamptz DEFAULT now(),
+  processed boolean DEFAULT false
+);
+
+-- posts
+CREATE TABLE IF NOT EXISTS posts (
+  post_id serial PRIMARY KEY,
+  installation_id bigint REFERENCES installations(installation_id),
+  repo_full_name text,
+  event_type text,
+  content_draft text,
+  created_at timestamptz DEFAULT now()
+);

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -19,7 +19,8 @@
         "test:watch": "jest --watch",
         "test:cov": "jest --coverage",
         "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
-        "test:e2e": "jest --config ./test/jest-e2e.json"
+        "test:e2e": "jest --config ./test/jest-e2e.json",
+        "worker:events": "ts-node src/github/github-events.worker.ts"
     },
     "dependencies": {
         "@nestjs/common": "^11.0.1",
@@ -37,6 +38,8 @@
         "bullmq": "^5.56.1",
         "@octokit/rest": "^20.0.0",
         "jsonwebtoken": "^9.0.2",
+        "@nestjs/typeorm": "^11.0.0",
+        "pg": "^8.11.3",
         "rxjs": "^7.8.1",
         "typeorm": "^0.3.25"
     },

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -1,16 +1,26 @@
 import { Module } from '@nestjs/common';
-import { ConfigModule } from '@nestjs/config';
+import { ConfigModule, ConfigService } from '@nestjs/config';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { AuthModule } from './auth/auth.module';
 import { UsersModule } from './users/users.module';
 import { GithubModule } from './github/github.module';
+import { TypeOrmModule } from '@nestjs/typeorm';
 
 @Module({
   imports: [
     ConfigModule.forRoot({
       isGlobal: true,
       envFilePath: '.env',
+    }),
+    TypeOrmModule.forRootAsync({
+      useFactory: (config: ConfigService) => ({
+        type: 'postgres',
+        url: config.get<string>('DATABASE_URL'),
+        autoLoadEntities: true,
+        synchronize: true,
+      }),
+      inject: [ConfigService],
     }),
     AuthModule,
     UsersModule,

--- a/apps/api/src/github/entities/event.entity.ts
+++ b/apps/api/src/github/entities/event.entity.ts
@@ -1,0 +1,24 @@
+import { Column, Entity, ManyToOne, JoinColumn, PrimaryColumn } from 'typeorm';
+import { Installation } from './installation.entity';
+
+@Entity({ name: 'events' })
+export class Event {
+  @PrimaryColumn('text')
+  delivery_id!: string;
+
+  @ManyToOne(() => Installation)
+  @JoinColumn({ name: 'installation_id' })
+  installation!: Installation;
+
+  @Column('text')
+  event!: string;
+
+  @Column('jsonb')
+  payload!: Record<string, unknown>;
+
+  @Column('timestamptz', { default: () => 'now()' })
+  received_at!: Date;
+
+  @Column('boolean', { default: false })
+  processed!: boolean;
+}

--- a/apps/api/src/github/entities/installation.entity.ts
+++ b/apps/api/src/github/entities/installation.entity.ts
@@ -1,0 +1,19 @@
+import { Column, Entity, PrimaryColumn } from 'typeorm';
+
+@Entity({ name: 'installations' })
+export class Installation {
+  @PrimaryColumn({ type: 'bigint' })
+  installation_id!: number;
+
+  @Column('text')
+  account_login!: string;
+
+  @Column('bigint')
+  account_id!: number;
+
+  @Column('text', { array: true, default: '{}' })
+  repos!: string[];
+
+  @Column('timestamptz', { default: () => 'now()' })
+  created_at!: Date;
+}

--- a/apps/api/src/github/entities/post.entity.ts
+++ b/apps/api/src/github/entities/post.entity.ts
@@ -1,0 +1,30 @@
+import {
+  Column,
+  Entity,
+  ManyToOne,
+  JoinColumn,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
+import { Installation } from './installation.entity';
+
+@Entity({ name: 'posts' })
+export class Post {
+  @PrimaryGeneratedColumn({ type: 'bigint' })
+  post_id!: number;
+
+  @ManyToOne(() => Installation)
+  @JoinColumn({ name: 'installation_id' })
+  installation!: Installation;
+
+  @Column('text')
+  repo_full_name!: string;
+
+  @Column('text')
+  event_type!: string;
+
+  @Column('text')
+  content_draft!: string;
+
+  @Column('timestamptz', { default: () => 'now()' })
+  created_at!: Date;
+}

--- a/apps/api/src/github/github-events.worker.ts
+++ b/apps/api/src/github/github-events.worker.ts
@@ -1,0 +1,80 @@
+import { QueueEvents, Worker, Job } from 'bullmq';
+import { DataSource } from 'typeorm';
+import { ConfigService } from '@nestjs/config';
+import { GithubAppService } from './github-app.service';
+import { Installation } from './entities/installation.entity';
+import { Event as GithubEvent } from './entities/event.entity';
+import { Post } from './entities/post.entity';
+import { Octokit } from '@octokit/rest';
+
+const config = new ConfigService();
+const dataSource = new DataSource({
+  type: 'postgres',
+  url: config.get<string>('DATABASE_URL'),
+  entities: [Installation, GithubEvent, Post],
+});
+
+async function bootstrap() {
+  await dataSource.initialize();
+  const service = new GithubAppService(
+    config,
+    dataSource.getRepository(Installation),
+    dataSource.getRepository(GithubEvent),
+    dataSource.getRepository(Post),
+  );
+
+  const worker = new Worker(
+    'github-events',
+    async (job: Job) => {
+      const { delivery_id } = job.data as { delivery_id: string };
+      const event = await service['events'].findOne({
+        where: { delivery_id },
+        relations: ['installation'],
+      });
+      if (!event || event.processed) return;
+      const installationId = event.installation.installation_id;
+      const octokit = await service.getInstallationOctokit(installationId);
+      let repoFullName = '';
+      if (event.event === 'push') {
+        const payload: any = event.payload;
+        repoFullName = payload.repository.full_name;
+        await octokit.rest.repos.getCommit({
+          owner: payload.repository.owner.login,
+          repo: payload.repository.name,
+          ref: payload.after,
+        });
+      } else if (event.event === 'pull_request') {
+        const payload: any = event.payload;
+        repoFullName = payload.repository.full_name;
+        await octokit.rest.pulls.get({
+          owner: payload.repository.owner.login,
+          repo: payload.repository.name,
+          pull_number: payload.number,
+        });
+      }
+      const content = `Draft for ${event.event} on ${repoFullName}`;
+      await service.savePost({
+        installationId,
+        repo: repoFullName,
+        eventType: event.event,
+        content,
+      });
+      await service.events.update({ delivery_id }, { processed: true });
+    },
+    {
+      connection: { url: config.get<string>('REDIS_URL') },
+    },
+  );
+
+  const queueEvents = new QueueEvents('github-events', {
+    connection: { url: config.get<string>('REDIS_URL') },
+  });
+  queueEvents.on('failed', ({ jobId, failedReason }) => {
+    console.error('Job failed', jobId, failedReason);
+  });
+}
+
+bootstrap().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/apps/api/src/github/github.module.ts
+++ b/apps/api/src/github/github.module.ts
@@ -4,9 +4,13 @@ import { GithubController } from './github.controller';
 import { WebhooksController } from './webhooks.controller';
 import { GithubAppService } from './github-app.service';
 import { UsersModule } from '../users/users.module';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Installation } from './entities/installation.entity';
+import { Event } from './entities/event.entity';
+import { Post } from './entities/post.entity';
 
 @Module({
-  imports: [UsersModule],
+  imports: [UsersModule, TypeOrmModule.forFeature([Installation, Event, Post])],
   controllers: [GithubController, WebhooksController],
   providers: [GithubService, GithubAppService],
 })

--- a/apps/api/src/github/webhooks.controller.ts
+++ b/apps/api/src/github/webhooks.controller.ts
@@ -9,11 +9,52 @@ export class WebhooksController {
   @Post()
   async handle(
     @Req() req: Request,
-    @Body() body: Record<string, unknown>,
+    @Body() body: any,
     @Headers('x-github-delivery') delivery: string,
+    @Headers('x-github-event') event: string,
   ): Promise<{ ok: boolean }> {
     this.appService.verifySignature(req);
-    await this.appService.enqueueEvent(delivery, body);
+
+    if (event === 'installation') {
+      const action = body.action;
+      const installation = body.installation;
+      if (action === 'created') {
+        await this.appService.upsertInstallation({
+          installation_id: installation.id,
+          account_login: installation.account.login,
+          account_id: installation.account.id,
+          repositories: body.repositories?.map((r: any) => r.full_name) || [],
+        });
+      } else if (action === 'deleted') {
+        await this.appService.removeInstallation(installation.id);
+      }
+      return { ok: true };
+    }
+
+    if (event === 'installation_repositories') {
+      const installationId = body.installation.id;
+      const { repositories_added = [], repositories_removed = [] } = body;
+      const current =
+        await this.appService.getInstallationRepos(installationId);
+      const added = repositories_added.map((r: any) => r.full_name);
+      const removed = repositories_removed.map((r: any) => r.full_name);
+      const repos = [
+        ...current.filter((r: string) => !removed.includes(r)),
+        ...added,
+      ];
+      await this.appService.updateRepos(
+        installationId,
+        Array.from(new Set(repos)),
+      );
+      return { ok: true };
+    }
+
+    if (event === 'push' || event === 'pull_request') {
+      const installationId = body.installation.id;
+      await this.appService.recordEvent(delivery, installationId, event, body);
+      return { ok: true };
+    }
+
     return { ok: true };
   }
 }

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -1,0 +1,4 @@
+NEXT_PUBLIC_API_URL=http://localhost:3001
+NEXTAUTH_URL=http://localhost:3000
+NEXTAUTH_SECRET=your_nextauth_secret
+NEXT_PUBLIC_GITHUB_APP_SLUG=quori

--- a/apps/web/app/dashboard/page.tsx
+++ b/apps/web/app/dashboard/page.tsx
@@ -4,9 +4,16 @@ import ProtectedRoute from "@/components/auth/ProtectedRoute";
 import { useSession, signOut } from "next-auth/react";
 import { Button } from "@/components/ui/button";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Github, User, Mail, Calendar, GithubIcon } from "lucide-react";
+import Link from "next/link";
 
 type ExtendedUser = {
   id: string;
@@ -145,9 +152,15 @@ function DashboardContent() {
             </CardTitle>
           </CardHeader>
           <CardContent>
-            <Button className="w-full">
-              Installer
-              <GithubIcon />
+            <Button asChild className="w-full">
+              <Link
+                href={`https://github.com/apps/${process.env.NEXT_PUBLIC_GITHUB_APP_SLUG}/installations/new`}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                Installer
+                <GithubIcon />
+              </Link>
             </Button>
           </CardContent>
         </Card>


### PR DESCRIPTION
## Summary
- link the dashboard button to GitHub App installation URL
- add example env file for the frontend
- create TypeORM entities for installations, events and posts
- persist webhooks in `GithubAppService`
- extend webhook controller for GitHub App events
- add a BullMQ worker for github events
- setup TypeORM in the API
- provide SQL migration script
- document localtunnel usage

## Testing
- `npm run format`
- `npm run lint` *(fails: Cannot find package '@repo/eslint-config' imported from packages/ui/eslint.config.mjs)*
- `npm run build` *(fails: nest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686aecb881b0832082be65cb10fc3ef6