### PR TITLE
Persist GitHub token securely

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,10 @@ GITHUB_WEBHOOK_SECRET="your_webhook_secret"
 # OpenAI
 OPENAI_API_KEY="sk-..."
 
+# Sessions & Encryption
+SESSION_SECRET="your-session-secret-key"
+ENCRYPTION_KEY="change-me"
+
 **apps/web/.env.local**
 ```bash
 NEXT_PUBLIC_API_URL="http://localhost:3001"

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -16,6 +16,7 @@ FRONTEND_URL=http://localhost:3000
 
 # Session Configuration
 SESSION_SECRET=your-session-secret-key
+ENCRYPTION_KEY=change-me
 
 # Database Configuration (pour plus tard)
 # DATABASE_URL=postgresql://username:password@localhost:5432/quori

--- a/apps/api/migrations/001-initial.sql
+++ b/apps/api/migrations/001-initial.sql
@@ -26,3 +26,18 @@ CREATE TABLE IF NOT EXISTS posts (
   content_draft text,
   created_at timestamptz DEFAULT now()
 );
+
+-- users
+CREATE TABLE IF NOT EXISTS users (
+  user_id text PRIMARY KEY,
+  github_id text,
+  username text,
+  email text,
+  avatar_url text,
+  name text,
+  github_access_token text,
+  refresh_token text,
+  refresh_token_expires timestamptz,
+  created_at timestamptz DEFAULT now(),
+  updated_at timestamptz DEFAULT now()
+);

--- a/apps/api/src/auth/auth-sync.controller.ts
+++ b/apps/api/src/auth/auth-sync.controller.ts
@@ -18,7 +18,7 @@ export class AuthSyncController {
 
   @Post('github/sync')
   @HttpCode(200)
-  syncGitHubUser(@Body() body: GitHubSyncDto) {
+  async syncGitHubUser(@Body() body: GitHubSyncDto) {
     // Convertir le profil GitHub au format attendu
     const profile = {
       id: body.githubProfile.id.toString(),
@@ -30,9 +30,12 @@ export class AuthSyncController {
       photos: [{ value: body.githubProfile.avatar_url }],
     };
 
-    const user = this.authService.validateGithubUser(profile, body.accessToken);
+    const user = await this.authService.validateGithubUser(
+      profile,
+      body.accessToken,
+    );
 
-    const { access_token, refresh_token } = this.authService.login(user);
+    const { access_token, refresh_token } = await this.authService.login(user);
 
     return {
       access_token,

--- a/apps/api/src/auth/auth.controller.ts
+++ b/apps/api/src/auth/auth.controller.ts
@@ -26,9 +26,9 @@ export class AuthController {
 
   @Get('github/callback')
   @UseGuards(AuthGuard('github'))
-  githubCallback(@Req() req: Request, @Res() res: Response) {
+  async githubCallback(@Req() req: Request, @Res() res: Response) {
     const user = req.user as User;
-    const loginResult = this.authService.login(user);
+    const loginResult = await this.authService.login(user);
 
     const redirectUrl = `${
       process.env.FRONTEND_URL || 'http://localhost:3000'
@@ -47,17 +47,17 @@ export class AuthController {
 
   @Post('logout')
   @UseGuards(JwtAuthGuard)
-  logout(@GetUser() user: User) {
-    this.authService.logout(user.id);
+  async logout(@GetUser() user: User) {
+    await this.authService.logout(user.id);
     return {
       message: 'Logged out successfully',
     };
   }
 
   @Post('refresh')
-  refresh(@Body('refreshToken') refreshToken: string) {
+  async refresh(@Body('refreshToken') refreshToken: string) {
     const { access_token, refresh_token, user } =
-      this.authService.refreshTokens(refreshToken);
+      await this.authService.refreshTokens(refreshToken);
     return { access_token, refresh_token, user };
   }
 

--- a/apps/api/src/auth/strategies/github.strategy.ts
+++ b/apps/api/src/auth/strategies/github.strategy.ts
@@ -24,11 +24,11 @@ export class GithubStrategy extends PassportStrategy(Strategy, 'github') {
     });
   }
 
-  validate(
+  async validate(
     accessToken: string,
     refreshToken: string,
     profile: GitHubProfile,
-  ): User {
-    return this.authService.validateGithubUser(profile);
+  ): Promise<User> {
+    return this.authService.validateGithubUser(profile, accessToken);
   }
 }

--- a/apps/api/src/auth/strategies/jwt.strategy.ts
+++ b/apps/api/src/auth/strategies/jwt.strategy.ts
@@ -21,8 +21,8 @@ export class JwtStrategy extends PassportStrategy(Strategy, 'jwt') {
     });
   }
 
-  validate(payload: JwtPayload): User {
-    const user = this.authService.validateJwtPayload(payload);
+  async validate(payload: JwtPayload): Promise<User> {
+    const user = await this.authService.validateJwtPayload(payload);
     if (!user) {
       throw new UnauthorizedException('Invalid token');
     }

--- a/apps/api/src/users/user.entity.ts
+++ b/apps/api/src/users/user.entity.ts
@@ -1,0 +1,37 @@
+import { Column, Entity, PrimaryColumn } from 'typeorm';
+
+@Entity({ name: 'users' })
+export class UserEntity {
+  @PrimaryColumn('text')
+  user_id!: string;
+
+  @Column('text')
+  github_id!: string;
+
+  @Column('text')
+  username!: string;
+
+  @Column('text')
+  email!: string;
+
+  @Column('text')
+  avatar_url!: string;
+
+  @Column('text')
+  name!: string;
+
+  @Column('text', { nullable: true })
+  github_access_token?: string;
+
+  @Column('text', { nullable: true })
+  refresh_token?: string;
+
+  @Column('timestamptz', { nullable: true })
+  refresh_token_expires?: Date;
+
+  @Column('timestamptz', { default: () => 'now()' })
+  created_at!: Date;
+
+  @Column('timestamptz', { default: () => 'now()' })
+  updated_at!: Date;
+}

--- a/apps/api/src/users/users.module.ts
+++ b/apps/api/src/users/users.module.ts
@@ -1,7 +1,10 @@
 import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
 import { UsersService } from './users.service';
+import { UserEntity } from './user.entity';
 
 @Module({
+  imports: [TypeOrmModule.forFeature([UserEntity])],
   providers: [UsersService],
   exports: [UsersService],
 })

--- a/apps/api/src/users/users.service.ts
+++ b/apps/api/src/users/users.service.ts
@@ -1,5 +1,9 @@
 import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
 import { User } from './user.interface';
+import { UserEntity } from './user.entity';
+import * as crypto from 'crypto';
 
 export interface GitHubProfile {
   id: string;
@@ -11,67 +15,120 @@ export interface GitHubProfile {
 
 @Injectable()
 export class UsersService {
-  private users: User[] = [];
+  private readonly secret =
+    process.env.ENCRYPTION_KEY || process.env.SESSION_SECRET || 'default-secret';
 
-  findByRefreshToken(refreshToken: string): User | undefined {
-    return this.users.find((user) => user.refreshToken === refreshToken);
+  constructor(
+    @InjectRepository(UserEntity)
+    private readonly repo: Repository<UserEntity>,
+  ) {}
+
+  private encrypt(value: string): string {
+    const key = crypto.createHash('sha256').update(this.secret).digest();
+    const iv = crypto.randomBytes(16);
+    const cipher = crypto.createCipheriv('aes-256-gcm', key, iv);
+    const encrypted = Buffer.concat([cipher.update(value, 'utf8'), cipher.final()]);
+    const tag = cipher.getAuthTag();
+    return `${iv.toString('hex')}:${tag.toString('hex')}:${encrypted.toString('hex')}`;
   }
 
-  findByGithubId(githubId: string): User | undefined {
-    return this.users.find((user) => user.githubId === githubId);
+  private decrypt(payload: string): string {
+    const [ivHex, tagHex, encHex] = payload.split(':');
+    const key = crypto.createHash('sha256').update(this.secret).digest();
+    const decipher = crypto.createDecipheriv('aes-256-gcm', key, Buffer.from(ivHex, 'hex'));
+    decipher.setAuthTag(Buffer.from(tagHex, 'hex'));
+    const decrypted = Buffer.concat([
+      decipher.update(Buffer.from(encHex, 'hex')),
+      decipher.final(),
+    ]);
+    return decrypted.toString('utf8');
   }
 
-  findById(id: string): User | undefined {
-    return this.users.find((user) => user.id === id);
+  async findByRefreshToken(refreshToken: string): Promise<User | undefined> {
+    const entity = await this.repo.findOne({ where: { refresh_token: refreshToken } });
+    return entity ? this.toUser(entity) : undefined;
   }
 
-  updateRefreshToken(
+  async findByGithubId(githubId: string): Promise<User | undefined> {
+    const entity = await this.repo.findOne({ where: { github_id: githubId } });
+    return entity ? this.toUser(entity) : undefined;
+  }
+
+  async findById(id: string): Promise<User | undefined> {
+    const entity = await this.repo.findOne({ where: { user_id: id } });
+    return entity ? this.toUser(entity) : undefined;
+  }
+
+  async updateRefreshToken(
     id: string,
     refreshToken: string | undefined,
     refreshTokenExpires?: Date,
-  ): void {
-    const userIndex = this.users.findIndex((user) => user.id === id);
-    if (userIndex === -1) return;
-    this.users[userIndex].refreshToken = refreshToken;
-    this.users[userIndex].refreshTokenExpires = refreshTokenExpires;
-    this.users[userIndex].updatedAt = new Date();
+  ): Promise<void> {
+    await this.repo.update(
+      { user_id: id },
+      {
+        refresh_token: refreshToken,
+        refresh_token_expires: refreshTokenExpires,
+        updated_at: new Date(),
+      },
+    );
   }
 
-  create(githubProfile: GitHubProfile, githubAccessToken?: string): User {
-    const user: User = {
-      id: this.generateId(),
-      githubId: githubProfile.id,
+  async create(githubProfile: GitHubProfile, githubAccessToken?: string): Promise<User> {
+    const entity: UserEntity = {
+      user_id: crypto.randomUUID(),
+      github_id: githubProfile.id,
       username: githubProfile.username,
       email: githubProfile.emails?.[0]?.value || '',
-      avatarUrl: githubProfile.photos?.[0]?.value || '',
+      avatar_url: githubProfile.photos?.[0]?.value || '',
       name: githubProfile.displayName || githubProfile.username,
-      githubAccessToken,
-      refreshToken: undefined,
-      refreshTokenExpires: undefined,
-      createdAt: new Date(),
-      updatedAt: new Date(),
+      github_access_token: githubAccessToken
+        ? this.encrypt(githubAccessToken)
+        : undefined,
+      refresh_token: undefined,
+      refresh_token_expires: undefined,
+      created_at: new Date(),
+      updated_at: new Date(),
     };
 
-    this.users.push(user);
-    return user;
+    const saved = await this.repo.save(entity);
+    return this.toUser(saved);
   }
 
-  update(id: string, updateData: Partial<User>): User | undefined {
-    const userIndex = this.users.findIndex((user) => user.id === id);
-    if (userIndex === -1) {
+  async update(id: string, updateData: Partial<User>): Promise<User | undefined> {
+    const entity = await this.repo.findOne({ where: { user_id: id } });
+    if (!entity) {
       return undefined;
     }
 
-    this.users[userIndex] = {
-      ...this.users[userIndex],
-      ...updateData,
-      updatedAt: new Date(),
-    };
+    if (updateData.username !== undefined) entity.username = updateData.username;
+    if (updateData.email !== undefined) entity.email = updateData.email;
+    if (updateData.avatarUrl !== undefined) entity.avatar_url = updateData.avatarUrl;
+    if (updateData.name !== undefined) entity.name = updateData.name;
+    if (updateData.githubAccessToken !== undefined) {
+      entity.github_access_token = this.encrypt(updateData.githubAccessToken);
+    }
+    entity.updated_at = new Date();
 
-    return this.users[userIndex];
+    const saved = await this.repo.save(entity);
+    return this.toUser(saved);
   }
 
-  private generateId(): string {
-    return Math.random().toString(36).substr(2, 9);
+  private toUser(entity: UserEntity): User {
+    return {
+      id: entity.user_id,
+      githubId: entity.github_id,
+      username: entity.username,
+      email: entity.email,
+      avatarUrl: entity.avatar_url,
+      name: entity.name,
+      githubAccessToken: entity.github_access_token
+        ? this.decrypt(entity.github_access_token)
+        : undefined,
+      refreshToken: entity.refresh_token,
+      refreshTokenExpires: entity.refresh_token_expires,
+      createdAt: entity.created_at,
+      updatedAt: entity.updated_at,
+    };
   }
 }


### PR DESCRIPTION
## Summary
- store users in PostgreSQL using TypeORM
- encrypt GitHub tokens at rest with AES
- add ENCRYPTION_KEY env variable
- make auth flows async
- update initial migration with users table

## Testing
- `npm test --silent` *(fails: turbo not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d963e582c8320a3d3af98cf30395e