### PR TITLE
Add GitHub event stream and activity feed

### DIFF
--- a/apps/api/src/github/entities/event.entity.ts
+++ b/apps/api/src/github/entities/event.entity.ts
@@ -16,6 +16,12 @@ export class Event {
   @Column('jsonb')
   payload!: Record<string, unknown>;
 
+  @Column('text')
+  repo_full_name!: string;
+
+  @Column('jsonb', { nullable: true })
+  metadata?: Record<string, unknown>;
+
   @Column('timestamptz', { default: () => 'now()' })
   received_at!: Date;
 

--- a/apps/api/src/github/github.controller.ts
+++ b/apps/api/src/github/github.controller.ts
@@ -6,6 +6,7 @@ import {
   Request,
   UnauthorizedException,
   Query,
+  Sse,
 } from '@nestjs/common';
 import { GithubService } from './github.service';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
@@ -13,6 +14,7 @@ import { UsersService } from '../users/users.service';
 import { GitHubRepository } from './interfaces/github-repository.interface';
 import { GitHubRepositoriesPage } from './interfaces/github-repositories-page.interface';
 import { User } from '../users/user.interface';
+import { GithubAppService } from './github-app.service';
 
 interface AuthenticatedRequest {
   user: User;
@@ -23,6 +25,7 @@ export class GithubController {
   constructor(
     private readonly githubService: GithubService,
     private readonly usersService: UsersService,
+    private readonly appService: GithubAppService,
   ) {}
 
   @UseGuards(JwtAuthGuard)
@@ -61,5 +64,18 @@ export class GithubController {
       owner,
       repo,
     );
+  }
+
+  @UseGuards(JwtAuthGuard)
+  @Get('events')
+  async getEvents(@Query('limit') limit = '20') {
+    const num = parseInt(limit, 10) || 20;
+    return this.appService.getRecentEvents(num);
+  }
+
+  @UseGuards(JwtAuthGuard)
+  @Sse('events/stream')
+  streamEvents() {
+    return this.appService.getEventStream();
   }
 }

--- a/apps/api/src/github/parse-git-event.ts
+++ b/apps/api/src/github/parse-git-event.ts
@@ -1,0 +1,91 @@
+import { Octokit } from '@octokit/rest';
+
+export interface ParsedGitEvent {
+  title: string;
+  desc: string;
+  filesChanged: string[];
+  diffStats: {
+    additions: number;
+    deletions: number;
+    total: number;
+  };
+}
+
+export async function parseGitEvent(
+  payload: Record<string, any>,
+  event: string,
+  octokit?: Octokit,
+): Promise<ParsedGitEvent> {
+  let title = '';
+  let desc = '';
+  let filesChanged: string[] = [];
+  let additions = 0;
+  let deletions = 0;
+
+  if (event === 'push') {
+    const repo = payload.repository;
+    const commitId = payload.after;
+    const head = payload.head_commit ?? payload.commits?.[payload.commits.length - 1];
+    title = head?.message?.split('\n')[0] || `Commit ${commitId}`;
+    desc = head?.message || '';
+    if (octokit) {
+      try {
+        const { data } = await octokit.rest.repos.getCommit({
+          owner: repo.owner.login,
+          repo: repo.name,
+          ref: commitId,
+        });
+        filesChanged = data.files?.map(f => f.filename) ?? [];
+        additions = data.stats?.additions ?? 0;
+        deletions = data.stats?.deletions ?? 0;
+      } catch {
+        // fallback to payload info
+        filesChanged = [
+          ...(head?.added || []),
+          ...(head?.modified || []),
+          ...(head?.removed || []),
+        ];
+      }
+    } else if (head) {
+      filesChanged = [
+        ...(head.added || []),
+        ...(head.modified || []),
+        ...(head.removed || []),
+      ];
+    }
+  } else if (event === 'pull_request') {
+    const repo = payload.repository;
+    const pr = payload.pull_request;
+    title = pr.title;
+    desc = pr.body || '';
+    additions = pr.additions ?? 0;
+    deletions = pr.deletions ?? 0;
+    if (octokit) {
+      try {
+        filesChanged = await octokit.paginate(
+          octokit.rest.pulls.listFiles,
+          {
+            owner: repo.owner.login,
+            repo: repo.name,
+            pull_number: pr.number,
+            per_page: 100,
+          },
+          res => res.data.map(f => f.filename),
+        );
+      } catch {
+        filesChanged = [];
+      }
+    }
+  }
+
+  return {
+    title,
+    desc,
+    filesChanged,
+    diffStats: {
+      additions,
+      deletions,
+      total: additions + deletions,
+    },
+  };
+}

--- a/apps/web/app/(protected)/activity/page.tsx
+++ b/apps/web/app/(protected)/activity/page.tsx
@@ -1,80 +1,9 @@
 "use client";
 
 import ProtectedRoute from "@/components/auth/ProtectedRoute";
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card";
-import { Button } from "@/components/ui/button";
-import { Badge } from "@/components/ui/badge";
-import {
-  Activity,
-  GitCommit,
-  GitPullRequest,
-  GitMerge,
-  Plus,
-} from "lucide-react";
+import ActivityFeed from "@/components/ActivityFeed";
 
-const ActivityPage = () => {
-  const activities = [
-    {
-      id: 1,
-      type: "commit",
-      title: "feat: add OAuth integration",
-      repository: "quori",
-      branch: "main",
-      timestamp: "2025-01-08T10:30:00Z",
-      hasPost: false,
-    },
-    {
-      id: 2,
-      type: "pull_request",
-      title: "Fix authentication bug",
-      repository: "api-service",
-      branch: "feature/auth-fix",
-      timestamp: "2025-01-08T09:15:00Z",
-      hasPost: true,
-    },
-    {
-      id: 3,
-      type: "merge",
-      title: "Merge feature/user-dashboard",
-      repository: "web-app",
-      branch: "main",
-      timestamp: "2025-01-07T16:20:00Z",
-      hasPost: false,
-    },
-  ];
-
-  const getActivityIcon = (type: string) => {
-    switch (type) {
-      case "commit":
-        return <GitCommit className="h-4 w-4" />;
-      case "pull_request":
-        return <GitPullRequest className="h-4 w-4" />;
-      case "merge":
-        return <GitMerge className="h-4 w-4" />;
-      default:
-        return <Activity className="h-4 w-4" />;
-    }
-  };
-
-  const getActivityBadge = (type: string) => {
-    switch (type) {
-      case "commit":
-        return <Badge variant="default">Commit</Badge>;
-      case "pull_request":
-        return <Badge variant="secondary">Pull Request</Badge>;
-      case "merge":
-        return <Badge variant="outline">Merge</Badge>;
-      default:
-        return <Badge variant="secondary">Activité</Badge>;
-    }
-  };
-
+export default function ActivityPage() {
   return (
     <ProtectedRoute>
       <div className="space-y-6">
@@ -84,55 +13,8 @@ const ActivityPage = () => {
             Chronologie de vos événements Git avec génération de posts en 1-clic
           </p>
         </div>
-
-        <div className="grid gap-4">
-          {activities.map(activity => (
-            <Card key={activity.id}>
-              <CardHeader>
-                <div className="flex items-center justify-between">
-                  <div className="flex items-center space-x-3">
-                    {getActivityIcon(activity.type)}
-                    <CardTitle className="text-lg">{activity.title}</CardTitle>
-                  </div>
-                  <div className="flex items-center space-x-2">
-                    {getActivityBadge(activity.type)}
-                    {activity.hasPost && (
-                      <Badge variant="destructive">Post généré</Badge>
-                    )}
-                  </div>
-                </div>
-                <CardDescription>
-                  {activity.repository} • {activity.branch} •{" "}
-                  {new Date(activity.timestamp).toLocaleDateString("fr-FR")} à{" "}
-                  {new Date(activity.timestamp).toLocaleTimeString("fr-FR", {
-                    hour: "2-digit",
-                    minute: "2-digit",
-                  })}
-                </CardDescription>
-              </CardHeader>
-              <CardContent>
-                <div className="flex items-center space-x-2">
-                  {!activity.hasPost ? (
-                    <Button size="sm">
-                      <Plus className="mr-2 h-4 w-4" />
-                      Générer un post
-                    </Button>
-                  ) : (
-                    <Button variant="outline" size="sm" disabled>
-                      Post déjà généré
-                    </Button>
-                  )}
-                  <Button variant="outline" size="sm">
-                    Voir les détails
-                  </Button>
-                </div>
-              </CardContent>
-            </Card>
-          ))}
-        </div>
+        <ActivityFeed />
       </div>
     </ProtectedRoute>
   );
-};
-
-export default ActivityPage;
+}

--- a/apps/web/components/ActivityFeed.tsx
+++ b/apps/web/components/ActivityFeed.tsx
@@ -1,0 +1,102 @@
+"use client";
+import { useEffect } from "react";
+import { useQueryClient, useQuery } from "@tanstack/react-query";
+import { authenticatedFetcher } from "@/hooks/useAuthenticatedQuery";
+import { GitHubEvent } from "@/types/githubEvent";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Activity, GitCommit, GitPullRequest } from "lucide-react";
+
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:3001/api";
+
+export default function ActivityFeed() {
+  const queryClient = useQueryClient();
+
+  const { data } = useQuery<GitHubEvent[]>({
+    queryKey: ["events"],
+    queryFn: () => authenticatedFetcher<GitHubEvent[]>("/github/events"),
+  });
+
+  useEffect(() => {
+    const es = new EventSource(`${API_BASE_URL}/github/events/stream`);
+    es.onmessage = (e) => {
+      try {
+        const event: GitHubEvent = JSON.parse(e.data);
+        queryClient.setQueryData<GitHubEvent[]>(["events"], (old) => {
+          const arr = old ? [event, ...old] : [event];
+          return arr.slice(0, 20);
+        });
+      } catch {
+        // ignore
+      }
+    };
+    es.onerror = () => {
+      es.close();
+    };
+    return () => es.close();
+  }, [queryClient]);
+
+  const getIcon = (type: string) => {
+    switch (type) {
+      case "push":
+        return <GitCommit className="h-4 w-4" />;
+      case "pull_request":
+        return <GitPullRequest className="h-4 w-4" />;
+      default:
+        return <Activity className="h-4 w-4" />;
+    }
+  };
+
+  const getBadge = (type: string) => {
+    switch (type) {
+      case "push":
+        return <Badge variant="default">Push</Badge>;
+      case "pull_request":
+        return <Badge variant="secondary">Pull Request</Badge>;
+      default:
+        return <Badge variant="secondary">Event</Badge>;
+    }
+  };
+
+  return (
+    <div className="grid gap-4">
+      {data?.map((activity) => (
+        <Card key={activity.delivery_id}>
+          <CardHeader>
+            <div className="flex items-center justify-between">
+              <div className="flex items-center space-x-3">
+                {getIcon(activity.event)}
+                <CardTitle className="text-lg">
+                  {activity.metadata?.title || activity.event}
+                </CardTitle>
+              </div>
+              <div className="flex items-center space-x-2">
+                {getBadge(activity.event)}
+              </div>
+            </div>
+            <CardDescription>
+              {activity.repo_full_name} • {new Date(activity.received_at).toLocaleString()}
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            {activity.metadata?.desc && (
+              <p className="mb-2 text-sm text-muted-foreground">
+                {activity.metadata.desc}
+              </p>
+            )}
+            <div className="flex items-center space-x-2">
+              <Button size="sm">Generer un post</Button>
+            </div>
+          </CardContent>
+        </Card>
+      ))}
+    </div>
+  );
+}

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -6,7 +6,8 @@
       "@/*": ["./*"],
       "@/components/*": ["./components/*"],
       "@/lib/*": ["./lib/*"],
-      "@/hooks/*": ["./hooks/*"]
+      "@/hooks/*": ["./hooks/*"],
+      "@/types/*": ["./types/*"]
     },
     "plugins": [
       {

--- a/apps/web/types/githubEvent.ts
+++ b/apps/web/types/githubEvent.ts
@@ -1,0 +1,18 @@
+export interface GitHubEventMeta {
+  title: string;
+  desc: string;
+  filesChanged: string[];
+  diffStats: {
+    additions: number;
+    deletions: number;
+    total: number;
+  };
+}
+
+export interface GitHubEvent {
+  delivery_id: string;
+  event: string;
+  repo_full_name: string;
+  metadata?: GitHubEventMeta;
+  received_at: string;
+}


### PR DESCRIPTION
## Summary
- store repo name and metadata for GitHub events
- parse push and PR payloads with `parseGitEvent`
- expose recent events and SSE stream endpoints
- implement ActivityFeed component and wire into protected activity page
- update tsconfig paths for shared types

## Testing
- `npm run lint` *(fails: turbo not installed)*
- `npm run test` *(fails: turbo not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686edff83fd8832080a755a5fef71f49