### PR TITLE
Add /github/generate endpoint

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -39,6 +39,7 @@
         "bullmq": "^5.56.1",
         "express-session": "^1.18.1",
         "jsonwebtoken": "^9.0.2",
+        "openai": "^4.32.2",
         "passport": "^0.7.0",
         "passport-github2": "^0.1.12",
         "passport-jwt": "^4.0.1",

--- a/apps/api/src/github/dto/generate.dto.ts
+++ b/apps/api/src/github/dto/generate.dto.ts
@@ -1,0 +1,32 @@
+export class DiffStatDto {
+  filePath!: string;
+  additions!: number;
+  deletions!: number;
+  changes!: number;
+}
+
+export class EventDto {
+  title!: string;
+  desc!: string;
+  filesChanged!: string[];
+  diffStats!: DiffStatDto[];
+  repoFullName!: string;
+  commitCount!: number;
+  timestamp!: string;
+}
+
+export class GenerateOptionsDto {
+  lang?: string;
+  tone?: string;
+  output?: string[];
+}
+
+export class GenerateDto {
+  event!: EventDto;
+  options?: GenerateOptionsDto;
+}
+
+export class GenerateResultDto {
+  summary!: string;
+  post!: string;
+}

--- a/apps/api/src/github/github.controller.ts
+++ b/apps/api/src/github/github.controller.ts
@@ -1,6 +1,8 @@
 import {
   Controller,
   Get,
+  Post,
+  Body,
   Param,
   UseGuards,
   Request,
@@ -21,6 +23,8 @@ import { GitHubRepositoriesPage } from './interfaces/github-repositories-page.in
 import { User } from '../users/user.interface';
 import { GithubAppService } from './github-app.service';
 import { JwtService } from '@nestjs/jwt';
+import { GenerateService } from './services/generate.service';
+import { GenerateDto, GenerateResultDto } from './dto/generate.dto';
 
 interface AuthenticatedRequest {
   user: User;
@@ -33,6 +37,7 @@ export class GithubController {
     private readonly usersService: UsersService,
     private readonly appService: GithubAppService,
     private readonly jwtService: JwtService,
+    private readonly generateService: GenerateService,
   ) {}
 
   @UseGuards(JwtAuthGuard)
@@ -260,5 +265,16 @@ export class GithubController {
     // Vider le cache pour cet utilisateur
     this.githubService.clearUserCache(user.githubAccessToken);
     return { message: 'Cache cleared successfully' };
+  }
+
+  @UseGuards(JwtAuthGuard)
+  @Post('generate')
+  async generatePost(
+    @Request() req: AuthenticatedRequest,
+    @Body() body: GenerateDto,
+  ): Promise<GenerateResultDto> {
+    const user = req.user;
+    const userId = user.id;
+    return this.generateService.generate(userId, body);
   }
 }

--- a/apps/api/src/github/github.module.ts
+++ b/apps/api/src/github/github.module.ts
@@ -3,6 +3,7 @@ import { GithubService } from './github.service';
 import { GithubController } from './github.controller';
 import { WebhooksController } from './webhooks.controller';
 import { GithubAppService } from './github-app.service';
+import { GenerateService } from './services/generate.service';
 import { UsersModule } from '../users/users.module';
 import { AuthModule } from '../auth/auth.module';
 import { TypeOrmModule } from '@nestjs/typeorm';
@@ -17,6 +18,6 @@ import { Post } from './entities/post.entity';
     TypeOrmModule.forFeature([Installation, Event, Post]),
   ],
   controllers: [GithubController, WebhooksController],
-  providers: [GithubService, GithubAppService],
+  providers: [GithubService, GithubAppService, GenerateService],
 })
 export class GithubModule {}

--- a/apps/api/src/github/services/generate.service.ts
+++ b/apps/api/src/github/services/generate.service.ts
@@ -1,0 +1,95 @@
+import {
+  BadRequestException,
+  ForbiddenException,
+  Injectable,
+} from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { OpenAI } from 'openai';
+import { GenerateDto, GenerateResultDto } from '../dto/generate.dto';
+
+interface QuotaInfo {
+  date: string;
+  count: number;
+}
+
+@Injectable()
+export class GenerateService {
+  private openai: OpenAI;
+  private quotas = new Map<string, QuotaInfo>();
+
+  constructor(private readonly config: ConfigService) {
+    const apiKey = this.config.get<string>('OPENAI_API_KEY');
+    if (!apiKey) {
+      throw new Error('OPENAI_API_KEY is not configured');
+    }
+    this.openai = new OpenAI({ apiKey });
+  }
+
+  private checkQuota(userId: string): void {
+    const today = new Date().toISOString().slice(0, 10);
+    const q = this.quotas.get(userId);
+    if (q && q.date === today) {
+      if (q.count >= 5) {
+        throw new ForbiddenException('Daily quota exceeded');
+      }
+      q.count += 1;
+    } else {
+      this.quotas.set(userId, { date: today, count: 1 });
+    }
+  }
+
+  private buildPrompt(dto: GenerateDto): string {
+    const { event, options } = dto;
+    const lang = options?.lang ?? 'français';
+    const tone = options?.tone ?? 'accessible, professionnel, léger humour';
+    const output = options?.output?.join(', ');
+
+    const stats = event.diffStats
+      .map(
+        (s) =>
+          `${s.filePath}: +${s.additions} -${s.deletions} (Δ ${s.changes})`,
+      )
+      .join('\n');
+
+    return [
+      `Contexte : dépôt ${event.repoFullName}, ${event.commitCount} commits, date ${event.timestamp}.`,
+      `Titre : ${event.title}`,
+      `Description : ${event.desc}`,
+      `Fichiers modifiés : ${event.filesChanged.join(', ')}`,
+      `Statistiques :\n${stats}`,
+      `Langue : ${lang}. Ton : ${tone}.`,
+      output ? `Sortie attendue : ${output}.` : '',
+      'Instructions : résumé en 3 phrases, puis une leçon à retenir, terminer par une question.',
+      'Réponds uniquement au format JSON strict : {"summary": "…", "post": "…"}',
+    ]
+      .filter(Boolean)
+      .join('\n');
+  }
+
+  async generate(userId: string, dto: GenerateDto): Promise<GenerateResultDto> {
+    this.checkQuota(userId);
+    const prompt = this.buildPrompt(dto);
+    console.debug('DEBUG ▶ prompt', prompt);
+    const res = await this.openai.chat.completions.create({
+      model: 'gpt-4o-mini',
+      messages: [{ role: 'user', content: prompt }],
+      temperature: 0.7,
+    });
+    const content = res.choices[0]?.message?.content ?? '';
+    console.debug('DEBUG ▶ response', content);
+    try {
+      const parsed = JSON.parse(content) as GenerateResultDto;
+      if (
+        typeof parsed.summary !== 'string' ||
+        typeof parsed.post !== 'string'
+      ) {
+        throw new Error('Invalid structure');
+      }
+      return parsed;
+    } catch (e) {
+      throw new BadRequestException(
+        `Failed to parse OpenAI response: ${(e as Error).message}`,
+      );
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- install OpenAI SDK
- implement `GenerateService` to build prompt, enforce quota and call OpenAI
- create DTOs for generation request/response
- register service in GithubModule
- expose authenticated POST `/github/generate` endpoint

## Testing
- `npm test` *(fails: Vitest cannot be imported in a CommonJS module)*

------
https://chatgpt.com/codex/tasks/task_e_6872d189e32c83208fe880a1914fdaa6