### PR TITLE
Implement daily OpenAI quota

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,20 @@ NEXTAUTH_URL="http://localhost:3000"
 NEXTAUTH_SECRET="your_nextauth_secret"
 ````
 
+## API Quota
+
+Deux routes sont disponibles pour suivre la consommation d'appels OpenAI :
+
+```http
+POST /api/generate
+GET  /api/quota
+```
+
+- `POST /api/generate` : génère un contenu et consomme 1 quota. Authentification JWT requise.
+- `GET /api/quota` : retourne l'utilisation courante `{ used: number, remaining: number }`.
+
+La limite est fixée à **5 requêtes par utilisateur et par jour**. Au-delà, l'API renvoie `429 Quota journalier dépassé`.
+
 ## Workflow de développement
 
 1. **Webhook GitHub** reçoit push/PR → parse les changements

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -40,6 +40,7 @@
         "express-session": "^1.18.1",
         "jsonwebtoken": "^9.0.2",
         "openai": "^4.32.2",
+        "ioredis": "^5.6.1",
         "passport": "^0.7.0",
         "passport-github2": "^0.1.12",
         "passport-jwt": "^4.0.1",

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -5,6 +5,7 @@ import { AppService } from './app.service';
 import { AuthModule } from './auth/auth.module';
 import { UsersModule } from './users/users.module';
 import { GithubModule } from './github/github.module';
+import { QuotaModule } from './quota/quota.module';
 import { TypeOrmModule } from '@nestjs/typeorm';
 
 @Module({
@@ -26,6 +27,7 @@ import { TypeOrmModule } from '@nestjs/typeorm';
     AuthModule,
     UsersModule,
     GithubModule,
+    QuotaModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/apps/api/src/github/github.module.ts
+++ b/apps/api/src/github/github.module.ts
@@ -19,5 +19,6 @@ import { Post } from './entities/post.entity';
   ],
   controllers: [GithubController, WebhooksController],
   providers: [GithubService, GithubAppService, GenerateService],
+  exports: [GenerateService],
 })
 export class GithubModule {}

--- a/apps/api/src/quota/quota.controller.ts
+++ b/apps/api/src/quota/quota.controller.ts
@@ -1,0 +1,51 @@
+import {
+  Controller,
+  Post,
+  Get,
+  Body,
+  Query,
+  UseGuards,
+  Request,
+} from '@nestjs/common';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { GenerateService } from '../github/services/generate.service';
+import { GenerateDto, GenerateResultDto } from '../github/dto/generate.dto';
+import { QuotaService } from './quota.service';
+
+interface AuthReq {
+  user: { id: string };
+}
+
+@UseGuards(JwtAuthGuard)
+@Controller()
+export class QuotaController {
+  constructor(
+    private readonly quotaService: QuotaService,
+    private readonly generateService: GenerateService,
+  ) {}
+
+  @Post('generate')
+  async generate(
+    @Request() req: AuthReq,
+    @Body() body: GenerateDto,
+    @Query('installationId') installationId?: string,
+    @Query('eventDeliveryId') eventDeliveryId?: string,
+  ): Promise<GenerateResultDto> {
+    const userId = req.user.id;
+    await this.quotaService.consume(userId);
+    const installation = installationId
+      ? parseInt(installationId, 10)
+      : undefined;
+    return this.generateService.generate(
+      userId,
+      body,
+      installation,
+      eventDeliveryId,
+    );
+  }
+
+  @Get('quota')
+  async getQuota(@Request() req: AuthReq) {
+    return this.quotaService.getUsage(req.user.id);
+  }
+}

--- a/apps/api/src/quota/quota.module.ts
+++ b/apps/api/src/quota/quota.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { QuotaService } from './quota.service';
+import { QuotaController } from './quota.controller';
+import { GithubModule } from '../github/github.module';
+
+@Module({
+  imports: [GithubModule],
+  providers: [QuotaService],
+  controllers: [QuotaController],
+})
+export class QuotaModule {}

--- a/apps/api/src/quota/quota.service.spec.ts
+++ b/apps/api/src/quota/quota.service.spec.ts
@@ -1,0 +1,51 @@
+import { QuotaService } from './quota.service';
+import { describe, it, expect, beforeAll, beforeEach } from 'vitest';
+
+class MockRedis {
+  private store = new Map<string, number>();
+  async incr(key: string) {
+    const val = (this.store.get(key) || 0) + 1;
+    this.store.set(key, val);
+    return val;
+  }
+  async expire(_key: string, _secs: number) {
+    return 1;
+  }
+  async get(key: string) {
+    const v = this.store.get(key);
+    return v ? String(v) : null;
+  }
+  async flushall() {
+    this.store.clear();
+  }
+}
+
+describe('QuotaService', () => {
+  let service: QuotaService;
+  const redis = new MockRedis();
+
+  beforeAll(() => {
+    service = new QuotaService({ get: () => undefined } as any);
+    (service as any).redis = redis;
+  });
+
+  beforeEach(async () => {
+    await redis.flushall();
+  });
+
+  it('allows up to 5 calls', async () => {
+    for (let i = 0; i < 5; i++) {
+      await expect(service.consume('u1')).resolves.toBeUndefined();
+    }
+    const usage = await service.getUsage('u1');
+    expect(usage.used).toBe(5);
+    expect(usage.remaining).toBe(0);
+  });
+
+  it('throws on 6th call', async () => {
+    for (let i = 0; i < 5; i++) {
+      await service.consume('u2');
+    }
+    await expect(service.consume('u2')).rejects.toBeDefined();
+  });
+});

--- a/apps/api/src/quota/quota.service.ts
+++ b/apps/api/src/quota/quota.service.ts
@@ -1,0 +1,37 @@
+import { Injectable, ForbiddenException } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { Redis } from 'ioredis';
+
+@Injectable()
+export class QuotaService {
+  private redis: Redis;
+  private readonly DAILY_LIMIT = 5;
+
+  constructor(private readonly config: ConfigService) {
+    const url =
+      this.config.get<string>('REDIS_URL') || 'redis://localhost:6379';
+    this.redis = new Redis(url);
+  }
+
+  private getKey(userId: string): string {
+    const today = new Date().toISOString().slice(0, 10);
+    return `quota:${userId}:${today}`;
+  }
+
+  async consume(userId: string): Promise<void> {
+    const key = this.getKey(userId);
+    const count = await this.redis.incr(key);
+    if (count === 1) {
+      await this.redis.expire(key, 24 * 60 * 60);
+    }
+    if (count > this.DAILY_LIMIT) {
+      throw new ForbiddenException('Daily quota exceeded');
+    }
+  }
+
+  async getUsage(userId: string): Promise<{ used: number; remaining: number }> {
+    const key = this.getKey(userId);
+    const count = parseInt((await this.redis.get(key)) || '0', 10);
+    return { used: count, remaining: Math.max(0, this.DAILY_LIMIT - count) };
+  }
+}

--- a/apps/api/vitest.config.ts
+++ b/apps/api/vitest.config.ts
@@ -5,6 +5,9 @@ export default defineConfig({
   test: {
     environment: 'node',
     globals: true,
-    include: ['src/github/parse-git-event.spec.ts'],
+    include: [
+      'src/github/parse-git-event.spec.ts',
+      'src/quota/quota.service.spec.ts',
+    ],
   },
 });

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -10,6 +10,7 @@ import { EventsProvider } from "@/contexts/EventsContext";
 import { NotificationsProvider } from "@/contexts/NotificationsContext";
 import { Toaster } from "react-hot-toast";
 import { DataProvider } from "@/contexts/DataContext";
+import { QuotaProvider } from "@/contexts/QuotaContext";
 
 export const metadata: Metadata = {
   title: "Quori",
@@ -29,12 +30,14 @@ export default function RootLayout({
             <NotificationsProvider>
               <EventsProvider>
                 <DataProvider>
-                  <SidebarProvider>
-                    <Header />
-                    <MainLayout>{children}</MainLayout>
-                    <Footer />
-                    <Toaster position="top-right" />
-                  </SidebarProvider>
+                  <QuotaProvider>
+                    <SidebarProvider>
+                      <Header />
+                      <MainLayout>{children}</MainLayout>
+                      <Footer />
+                      <Toaster position="top-right" />
+                    </SidebarProvider>
+                  </QuotaProvider>
                 </DataProvider>
               </EventsProvider>
             </NotificationsProvider>

--- a/apps/web/components/QuotaBadge.tsx
+++ b/apps/web/components/QuotaBadge.tsx
@@ -1,0 +1,28 @@
+"use client";
+import { Badge } from "@/components/ui/badge";
+import { Spinner } from "@/components/ui/spinner";
+import { useQuota } from "@/contexts/QuotaContext";
+
+export default function QuotaBadge() {
+  const { quota, isLoading, error } = useQuota();
+
+  if (isLoading) {
+    return <Spinner size="small" />;
+  }
+
+  if (error) {
+    return (
+      <Badge variant="destructive" title={error}>
+        {error}
+      </Badge>
+    );
+  }
+
+  if (!quota) return null;
+
+  return (
+    <Badge variant="secondary">
+      Quota utilisé : {quota.used}/5 — Restant : {quota.remaining}
+    </Badge>
+  );
+}

--- a/apps/web/components/layout/Header.tsx
+++ b/apps/web/components/layout/Header.tsx
@@ -17,6 +17,7 @@ import { Sheet, SheetTrigger, SheetContent } from "@/components/ui/sheet";
 import { Avatar, AvatarImage, AvatarFallback } from "@/components/ui/avatar";
 import Sidebar from "./Sidebar";
 import InboxPopover from "../InboxPopover";
+import QuotaBadge from "../QuotaBadge";
 
 import {
   Search,
@@ -194,6 +195,7 @@ const Header: React.FC = () => {
               <GitBranch className="h-5 w-5" />
             </Button>
             <InboxPopover />
+            <QuotaBadge />
           </nav>
         )}
 

--- a/apps/web/contexts/QuotaContext.tsx
+++ b/apps/web/contexts/QuotaContext.tsx
@@ -1,0 +1,59 @@
+"use client";
+import { createContext, useContext, useState, useEffect, ReactNode } from "react";
+import { authenticatedFetcher } from "@/hooks/useAuthenticatedQuery";
+import { useSession } from "next-auth/react";
+
+interface Quota {
+  used: number;
+  remaining: number;
+}
+
+interface QuotaContextType {
+  quota: Quota | null;
+  isLoading: boolean;
+  error: string | null;
+  refresh: () => void;
+}
+
+const QuotaContext = createContext<QuotaContextType | undefined>(undefined);
+
+export function QuotaProvider({ children }: { children: ReactNode }) {
+  const { data: session } = useSession();
+  const [quota, setQuota] = useState<Quota | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchQuota = async () => {
+    setIsLoading(true);
+    try {
+      const data = await authenticatedFetcher<Quota>("/quota");
+      setQuota(data);
+      setError(null);
+    } catch {
+      setError("Impossible de récupérer le quota");
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    if (session) {
+      fetchQuota();
+    }
+  }, [session]);
+
+  const value: QuotaContextType = {
+    quota,
+    isLoading,
+    error,
+    refresh: fetchQuota,
+  };
+
+  return <QuotaContext.Provider value={value}>{children}</QuotaContext.Provider>;
+}
+
+export function useQuota() {
+  const ctx = useContext(QuotaContext);
+  if (!ctx) throw new Error("useQuota must be used within a QuotaProvider");
+  return ctx;
+}

--- a/apps/web/hooks/useGeneratePost.ts
+++ b/apps/web/hooks/useGeneratePost.ts
@@ -14,7 +14,7 @@
  * 3. L'utilisateur peut personnaliser les options et générer le contenu
  * 4. Le résultat est affiché avec options de copie et sauvegardé automatiquement
  *
- * API endpoint : POST /github/generate
+ * API endpoint : POST /generate
  * - Authentification JWT requise
  * - Données d'événement + options de génération + paramètres de sauvegarde
  * - Retourne un résumé et un post formaté
@@ -23,6 +23,7 @@
 
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { authenticatedFetcher } from "./useAuthenticatedQuery";
+import { useQuota } from "@/contexts/QuotaContext";
 import { GitHubEvent } from "@/types/githubEvent";
 
 interface GeneratePostRequest {
@@ -58,6 +59,8 @@ interface GeneratePostResponse {
 export function useGeneratePost() {
   const queryClient = useQueryClient();
 
+  const { refresh } = useQuota();
+
   return useMutation<
     GeneratePostResponse,
     Error,
@@ -74,7 +77,7 @@ export function useGeneratePost() {
         params.append("eventDeliveryId", event.delivery_id);
       }
 
-      const url = `/github/generate${params.toString() ? `?${params.toString()}` : ""}`;
+      const url = `/generate${params.toString() ? `?${params.toString()}` : ""}`;
 
       return authenticatedFetcher<GeneratePostResponse>(url, {
         method: "POST",
@@ -92,6 +95,7 @@ export function useGeneratePost() {
 
       // Optionnel: invalider aussi les événements pour refléter qu'ils ont été traités
       queryClient.invalidateQueries({ queryKey: ["events"] });
+      refresh();
     },
   });
 }


### PR DESCRIPTION
## Summary
- enforce a limit of 5 `/generate` calls per user and day
- add `QuotaService`, `QuotaController` and module wired with Redis
- expose GET `/quota` and POST `/generate`
- display quota badge in the web header via new context
- refresh quota after each generation
- document quota endpoints
- add unit tests for `QuotaService`

## Testing
- `npm --workspace=api run test:unit`

------
https://chatgpt.com/codex/tasks/task_e_687406169b6c8320a7a8129ee0af70b8