### PR TITLE
Add TypeORM migration generation

### DIFF
--- a/apps/api/README.md
+++ b/apps/api/README.md
@@ -96,3 +96,22 @@ Nest is an MIT-licensed open source project. It can grow thanks to the sponsors 
 ## License
 
 Nest is [MIT licensed](https://github.com/nestjs/nest/blob/master/LICENSE).
+
+## Migrations
+
+Les migrations TypeORM utilisent le fichier `data-source.ts` à la racine du
+workspace `api`.
+
+### Générer une migration
+
+```bash
+npm --workspace=api run generate-migration -- <NomMigration>
+```
+
+Le fichier sera créé dans `apps/api/migrations`.
+
+### Exécuter les migrations
+
+```bash
+npm --workspace=api run migrate
+```

--- a/apps/api/data-source.ts
+++ b/apps/api/data-source.ts
@@ -1,0 +1,9 @@
+import 'dotenv/config';
+import { DataSource } from 'typeorm';
+
+export default new DataSource({
+  type: 'postgres',
+  url: process.env.DATABASE_URL,
+  entities: ['src/**/*.entity.ts'],
+  migrations: ['migrations/*.ts'],
+});

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -23,7 +23,9 @@
         "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
         "test:e2e": "jest --config ./test/jest-e2e.json",
         "worker:events": "ts-node src/github/github-events.worker.ts",
-        "migrate": "ts-node scripts/run-migrations.ts"
+        "migrate": "ts-node scripts/run-migrations.ts",
+        "typeorm": "typeorm-ts-node-commonjs",
+        "generate-migration": "ts-node scripts/generate-migration.ts"
     },
     "dependencies": {
         "@nestjs/common": "^11.0.1",

--- a/apps/api/scripts/generate-migration.ts
+++ b/apps/api/scripts/generate-migration.ts
@@ -1,0 +1,17 @@
+#!/usr/bin/env ts-node
+import { spawnSync } from 'child_process';
+import path from 'path';
+
+const name = process.argv[2];
+if (!name) {
+  console.error('Usage: npm --workspace=api run generate-migration -- <Name>');
+  process.exit(1);
+}
+
+const dataSource = path.join(__dirname, '../data-source.ts');
+const result = spawnSync(
+  'npx',
+  ['typeorm-ts-node-commonjs', '-d', dataSource, 'migration:generate', path.join('migrations', name)],
+  { stdio: 'inherit' },
+);
+process.exit(result.status === null ? 1 : result.status);


### PR DESCRIPTION
## Summary
- expose data source for TypeORM CLI
- add `generate-migration` helper script
- document how to work with migrations

## Testing
- `npm test` *(fails: Vitest cannot be imported in CommonJS modules)*

------
https://chatgpt.com/codex/tasks/task_e_687eb62dd4a88320bd23734a61192187