### PR TITLE
Fix LinkedIn callback and session refresh

### DIFF
--- a/apps/api/src/linkedin-auth/linkedin-auth.controller.spec.ts
+++ b/apps/api/src/linkedin-auth/linkedin-auth.controller.spec.ts
@@ -5,9 +5,14 @@ import { ConfigService } from '@nestjs/config';
 describe('LinkedinAuthController', () => {
   it('redirects to LinkedIn', () => {
     const service = {} as LinkedinAuthService;
-    const controller = new LinkedinAuthController(new ConfigService(), service);
+    const users = {} as any;
+    const controller = new LinkedinAuthController(
+      new ConfigService(),
+      service,
+      users,
+    );
     const res = { redirect: jest.fn() } as any;
-    controller.redirect(res);
+    controller.redirect(res, 'u1');
     expect(res.redirect).toHaveBeenCalled();
   });
 });

--- a/apps/api/src/linkedin-auth/linkedin-auth.controller.ts
+++ b/apps/api/src/linkedin-auth/linkedin-auth.controller.ts
@@ -78,6 +78,7 @@ export class LinkedinAuthController {
         data.access_token,
         data.expires_in || 0,
       );
+      console.log('Token stored in Redis for user', userId);
 
       // Récupérer l'id LinkedIn de l'utilisateur
       const profileResp = await fetch('https://api.linkedin.com/v2/userinfo', {
@@ -93,6 +94,7 @@ export class LinkedinAuthController {
         await this.usersService.updateLinkedInId(userId, linkedInId);
         await this.usersService.updateLinkedInToken(userId, data.access_token);
         console.log('User updated successfully');
+        console.log('LinkedIn data saved in database for user', userId);
       }
       const front =
         this.config.get<string>('FRONTEND_URL') || 'http://localhost:3000';

--- a/apps/web/hooks/useLinkedInStatus.ts
+++ b/apps/web/hooks/useLinkedInStatus.ts
@@ -5,19 +5,23 @@ import { useEffect, useState } from "react";
 export function useLinkedInStatus() {
   const { data: session, update: updateSession } = useSession();
   const searchParams = useSearchParams();
+  const linkedinStatus = searchParams.get("linkedin");
   const user = session?.user;
   const [hasRefreshed, setHasRefreshed] = useState(false);
 
   useEffect(() => {
-    const linkedinStatus = searchParams.get("linkedin");
     if (linkedinStatus === "success" && !hasRefreshed) {
       setHasRefreshed(true);
-      // Délai pour éviter la boucle
-      setTimeout(() => {
-        updateSession();
-      }, 100);
+      updateSession().then(() => {
+        const params = new URLSearchParams(window.location.search);
+        params.delete("linkedin");
+        const newUrl =
+          window.location.pathname +
+          (params.toString() ? `?${params.toString()}` : "");
+        window.history.replaceState({}, "", newUrl);
+      });
     }
-  }, [searchParams, updateSession, hasRefreshed]);
+  }, [linkedinStatus, updateSession, hasRefreshed]);
 
   return {
     isConnected: !!user?.linkedInId,


### PR DESCRIPTION
## Summary
- update NextAuth session so LinkedIn data is stored
- refresh user data on session update
- clear query params after LinkedIn callback to stop loops
- log LinkedIn token and DB updates
- fix LinkedIn controller test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6884fefbe8f48320b300f4bffb28c99c