### PR TITLE
feat: secure sse with auth header

### DIFF
--- a/apps/web/components/profile/UserPreferencesForm.tsx
+++ b/apps/web/components/profile/UserPreferencesForm.tsx
@@ -20,11 +20,6 @@ const LANGUAGES = [
   { value: "espagnol", label: "Espagnol" },
 ];
 
-const OUTPUTS = [
-  { value: "summary", label: "Résumé" },
-  { value: "post", label: "Post" },
-  { value: "tweet", label: "Tweet" },
-];
 
 export function UserPreferencesForm() {
   const { preferences, isLoading, error, savePreferences } = useUserPreferences();
@@ -37,8 +32,11 @@ export function UserPreferencesForm() {
     if (preferences) setForm(preferences);
   }, [preferences]);
 
-  const handleChange = (field: keyof UserPreferences, value: any) => {
-    setForm(f => ({ ...f, [field]: value }));
+  const handleChange = (
+    field: keyof UserPreferences,
+    value: unknown
+  ) => {
+    setForm(f => ({ ...f, [field]: value as never }));
   };
 
   const handleArrayChange = (field: keyof UserPreferences, value: string) => {
@@ -53,8 +51,12 @@ export function UserPreferencesForm() {
     try {
       await savePreferences(form);
       setSuccess(true);
-    } catch (e: any) {
-      setErrMsg(e.message || "Erreur lors de la sauvegarde");
+    } catch (e: unknown) {
+      setErrMsg(
+        e && typeof e === "object" && "message" in e
+          ? String((e as { message: string }).message)
+          : "Erreur lors de la sauvegarde"
+      );
     } finally {
       setSaving(false);
     }

--- a/apps/web/lib/api-client.ts
+++ b/apps/web/lib/api-client.ts
@@ -4,7 +4,7 @@ const API_BASE_URL =
   process.env.NEXT_PUBLIC_API_URL || "http://localhost:3001/api";
 
 // Cache pour la session pour éviter les appels répétés
-let sessionCache: any = null;
+let sessionCache: Awaited<ReturnType<typeof getSession>> | null = null;
 let sessionCacheTime = 0;
 const SESSION_CACHE_DURATION = 30000; // 30 secondes
 
@@ -26,8 +26,7 @@ export const authenticatedFetch = async (
     "Content-Type": "application/json",
     ...(options.headers as Record<string, string>),
   };
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const apiToken = (sessionCache as any)?.apiToken as string | undefined;
+  const apiToken = sessionCache?.apiToken as string | undefined;
   if (apiToken) {
     headers.Authorization = `Bearer ${apiToken}`;
   }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -50,7 +50,8 @@
     "tailwind-merge": "^3.3.1",
     "tailwindcss": "^4.1.11",
     "zod": "^3.25.74",
-    "zustand": "^5.0.6"
+    "zustand": "^5.0.6",
+    "event-source-polyfill": "^1.0.31"
   },
   "devDependencies": {
     "@repo/eslint-config": "*",
@@ -59,6 +60,7 @@
     "@types/node": "^22.15.3",
     "@types/react": "19.1.0",
     "@types/react-dom": "19.1.1",
+    "@types/event-source-polyfill": "^1.0.5",
     "eslint": "^9.30.0",
     "tw-animate-css": "^1.3.5",
     "typescript": "5.8.2"

--- a/package-lock.json
+++ b/package-lock.json
@@ -137,6 +137,7 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "date-fns": "^4.1.0",
+        "event-source-polyfill": "^1.0.31",
         "framer-motion": "^12.23.0",
         "lucide-react": "^0.525.0",
         "next": "^15.3.0",
@@ -158,6 +159,7 @@
         "@repo/eslint-config": "*",
         "@repo/typescript-config": "*",
         "@tanstack/react-query-devtools": "^5.81.5",
+        "@types/event-source-polyfill": "^1.0.5",
         "@types/node": "^22.15.3",
         "@types/react": "19.1.0",
         "@types/react-dom": "19.1.1",
@@ -946,7 +948,7 @@
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
       "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/trace-mapping": "0.3.9"
@@ -959,7 +961,7 @@
       "version": "0.3.9",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
       "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
@@ -5949,6 +5951,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -5966,6 +5969,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -5983,6 +5987,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -6000,6 +6005,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -6017,6 +6023,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -6034,6 +6041,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -6051,6 +6059,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -6068,6 +6077,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -6085,6 +6095,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -6102,6 +6113,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -6496,28 +6508,28 @@
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz",
       "integrity": "sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@tsconfig/node12": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
       "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@tsconfig/node14": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
       "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@tsconfig/node16": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
       "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@turbo/gen": {
@@ -6928,6 +6940,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/event-source-polyfill": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/event-source-polyfill/-/event-source-polyfill-1.0.5.tgz",
+      "integrity": "sha512-iaiDuDI2aIFft7XkcwMzDWLqo7LVDixd2sR6B4wxJut9xcp/Ev9bO4EFg4rm6S9QxATLBj5OPxdeocgmhjwKaw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/express": {
       "version": "5.0.3",
       "resolved": "https://registry.npmjs.org/@types/express/-/express-5.0.3.tgz",
@@ -7225,7 +7244,7 @@
       "version": "19.1.0",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.0.tgz",
       "integrity": "sha512-UaicktuQI+9UKyA4njtDOGBD/67t8YEBt2xdfqu8+gP9hqPUPsiXlNPcpS2gVdjmis5GKPG3fCxbQLVgxsQZ8w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.0.2"
@@ -7235,7 +7254,7 @@
       "version": "19.1.1",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.1.1.tgz",
       "integrity": "sha512-jFf/woGTVTjUJsl2O7hcopJ1r0upqoq/vIOoCj0yLh3RIXxWcljlpuZ+vEBRXsymD1jhfeJrlyTy/S1UW+4y1w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.0.0"
@@ -8435,7 +8454,7 @@
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
@@ -8458,7 +8477,7 @@
       "version": "8.3.4",
       "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
       "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "acorn": "^8.11.0"
@@ -8705,7 +8724,7 @@
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
       "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/argparse": {
@@ -10441,7 +10460,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/cron": {
@@ -10841,7 +10860,7 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
       "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
@@ -11748,6 +11767,12 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/event-source-polyfill": {
+      "version": "1.0.31",
+      "resolved": "https://registry.npmjs.org/event-source-polyfill/-/event-source-polyfill-1.0.31.tgz",
+      "integrity": "sha512-4IJSItgS/41IxN5UVAVuAyczwZF7ZIEsM1XAoUzIHA6A+xzusEZUutdXz2Nr+MQPLxfTiCvqE79/C8HT8fKFvA==",
+      "license": "MIT"
     },
     "node_modules/event-target-shim": {
       "version": "5.0.1",
@@ -15976,7 +16001,7 @@
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
       "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC"
     },
     "node_modules/makeerror": {
@@ -20629,7 +20654,7 @@
       "version": "10.9.2",
       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
@@ -21175,7 +21200,7 @@
       "version": "5.8.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.2.tgz",
       "integrity": "sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -21486,7 +21511,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
       "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/v8-to-istanbul": {
@@ -22238,7 +22263,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
       "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"


### PR DESCRIPTION
## Summary
- secure SSE hooks by sending auth token in Authorization header
- accept header-based tokens in API SSE endpoints
- add event-source polyfill and typings

## Testing
- `npm test` *(fails: Test Suites: 1 failed, 7 passed, 8 total)*
- `npm run lint` *(fails: see output for lint warnings)*
- `npm run check-types` *(fails: missing testing-library types)*

------
https://chatgpt.com/codex/tasks/task_e_688c80118bec832086eedb9953e08a11