### PR TITLE
chore: update GitHub webhook endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ npm run dev        # lance l'application
 
 ### Tester les webhooks GitHub
 
-Configurez l'URL `https://<sous-domaine>.loca.lt/webhooks/github` dans les
+Configurez l'URL `https://<sous-domaine>.loca.lt/github/events` dans les
 paramètres de votre GitHub App puis installez l'app depuis le dashboard.
 
 ## Architecture

--- a/apps/api/src/github/webhooks.controller.ts
+++ b/apps/api/src/github/webhooks.controller.ts
@@ -5,7 +5,7 @@ import { GithubAppService } from './github-app.service';
 //TODO : retirer les commentaires eslint une fois le code validé
 /* eslint-disable @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-argument */
 
-@Controller('webhooks/github')
+@Controller('github/events')
 export class WebhooksController {
   constructor(private readonly appService: GithubAppService) {}
 

--- a/apps/web/app/(protected)/integrations/page.tsx
+++ b/apps/web/app/(protected)/integrations/page.tsx
@@ -52,14 +52,14 @@ const IntegrationsPage = () => {
     {
       id: 1,
       name: "Push Events",
-      url: "https://api.quori.dev/webhooks/github/push",
+      url: "https://api.quori.dev/github/events",
       status: "active",
       events: ["push", "pull_request"],
     },
     {
       id: 2,
       name: "Release Events",
-      url: "https://api.quori.dev/webhooks/github/release",
+      url: "https://api.quori.dev/github/events",
       status: "active",
       events: ["release"],
     },


### PR DESCRIPTION
## Summary
- update GitHub webhooks controller path to `github/events`
- refresh docs and sample integration URLs for the new endpoint

## Testing
- `npm test` *(fails: LinkedinPublisherService dependency resolution)*
- `npm run lint` *(fails: Next.js lint reports warnings as errors)*

------
https://chatgpt.com/codex/tasks/task_e_688cf57b9668832090315399f764563d