### PR TITLE
fix(api): register events stream route before id

### DIFF
--- a/apps/api/src/github/github.controller.ts
+++ b/apps/api/src/github/github.controller.ts
@@ -162,6 +162,52 @@ export class GithubController {
     return this.appService.getEventsPaginated(pageNum, limitNum);
   }
 
+  @Sse('events/stream')
+  streamEventsWithUpdates(
+    @Headers('authorization') authHeader: string,
+    @Res({ passthrough: true }) res: Response,
+  ): Observable<{ data: string; type: string }> {
+    // Configuration CORS spécifique pour les SSE
+    res.setHeader(
+      'Access-Control-Allow-Origin',
+      process.env.FRONTEND_URL || 'http://localhost:3000',
+    );
+    res.setHeader('Access-Control-Allow-Credentials', 'true');
+    res.setHeader('Access-Control-Allow-Methods', 'GET');
+    res.setHeader(
+      'Access-Control-Allow-Headers',
+      'Cache-Control, Last-Event-ID',
+    );
+    res.setHeader('Cache-Control', 'no-cache');
+    res.setHeader('Connection', 'keep-alive');
+    res.setHeader('Content-Type', 'text/event-stream; charset=utf-8');
+
+    // Vérifier le token
+    this.verifyToken(undefined, authHeader);
+
+    return this.appService.getEventsStreamWithUpdates().pipe(
+      map((data) => ({
+        data: JSON.stringify(data),
+        type: data.type,
+      })),
+    );
+  }
+
+  @Options('events/stream')
+  handleEventsStreamOptions(@Res() res: Response) {
+    res.setHeader(
+      'Access-Control-Allow-Origin',
+      process.env.FRONTEND_URL || 'http://localhost:3000',
+    );
+    res.setHeader('Access-Control-Allow-Credentials', 'true');
+    res.setHeader('Access-Control-Allow-Methods', 'GET');
+    res.setHeader(
+      'Access-Control-Allow-Headers',
+      'Cache-Control, Last-Event-ID',
+    );
+    res.status(200).send();
+  }
+
   @UseGuards(JwtAuthGuard)
   @Get('events/:id')
   async getEventById(@Param('id') id: string) {
@@ -259,52 +305,6 @@ export class GithubController {
 
   @Options('posts/stats/stream')
   handlePostsStatsStreamOptions(@Res() res: Response) {
-    res.setHeader(
-      'Access-Control-Allow-Origin',
-      process.env.FRONTEND_URL || 'http://localhost:3000',
-    );
-    res.setHeader('Access-Control-Allow-Credentials', 'true');
-    res.setHeader('Access-Control-Allow-Methods', 'GET');
-    res.setHeader(
-      'Access-Control-Allow-Headers',
-      'Cache-Control, Last-Event-ID',
-    );
-    res.status(200).send();
-  }
-
-  @Sse('events/stream')
-  streamEventsWithUpdates(
-    @Headers('authorization') authHeader: string,
-    @Res({ passthrough: true }) res: Response,
-  ): Observable<{ data: string; type: string }> {
-    // Configuration CORS spécifique pour les SSE
-    res.setHeader(
-      'Access-Control-Allow-Origin',
-      process.env.FRONTEND_URL || 'http://localhost:3000',
-    );
-    res.setHeader('Access-Control-Allow-Credentials', 'true');
-    res.setHeader('Access-Control-Allow-Methods', 'GET');
-    res.setHeader(
-      'Access-Control-Allow-Headers',
-      'Cache-Control, Last-Event-ID',
-    );
-    res.setHeader('Cache-Control', 'no-cache');
-    res.setHeader('Connection', 'keep-alive');
-    res.setHeader('Content-Type', 'text/event-stream; charset=utf-8');
-
-    // Vérifier le token
-    this.verifyToken(undefined, authHeader);
-
-    return this.appService.getEventsStreamWithUpdates().pipe(
-      map((data) => ({
-        data: JSON.stringify(data),
-        type: data.type,
-      })),
-    );
-  }
-
-  @Options('events/stream')
-  handleEventsStreamOptions(@Res() res: Response) {
     res.setHeader(
       'Access-Control-Allow-Origin',
       process.env.FRONTEND_URL || 'http://localhost:3000',

--- a/apps/api/src/linkedin/linkedin-publisher.service.spec.ts
+++ b/apps/api/src/linkedin/linkedin-publisher.service.spec.ts
@@ -5,6 +5,7 @@ import { getRepositoryToken } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { Post } from '../github/entities/post.entity';
 import { LinkedInApi } from './linkedin.api';
+import { UsersService } from '../users/users.service';
 
 describe('LinkedinPublisherService', () => {
   let service: LinkedinPublisherService;
@@ -14,6 +15,7 @@ describe('LinkedinPublisherService', () => {
   } as unknown as jest.Mocked<Repository<Post>>;
   const auth = { getToken: jest.fn() } as unknown as jest.Mocked<LinkedinAuthService>;
   const api = { createPost: jest.fn() } as jest.Mocked<LinkedInApi>;
+  const users = { findById: jest.fn() } as unknown as jest.Mocked<UsersService>;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -22,6 +24,7 @@ describe('LinkedinPublisherService', () => {
         { provide: getRepositoryToken(Post), useValue: repo },
         { provide: LinkedinAuthService, useValue: auth },
         { provide: 'LinkedInApi', useValue: api },
+        { provide: UsersService, useValue: users },
       ],
     }).compile();
     service = module.get(LinkedinPublisherService);
@@ -31,6 +34,7 @@ describe('LinkedinPublisherService', () => {
     repo.findOne.mockResolvedValue({ id: 1, postContent: 'hi', statusLinkedin: 'pending' } as any);
     auth.getToken.mockResolvedValue('tok');
     api.createPost.mockResolvedValue({ id: 'abc' });
+    users.findById.mockResolvedValue({ linkedInId: 'lid' } as any);
 
     await service.publish('u1', 1);
 


### PR DESCRIPTION
## Summary
- ensure `/github/events/stream` SSE route is defined before the dynamic `events/:id` route
- add missing UsersService mock to LinkedInPublisherService tests

## Testing
- `npm test`
- `npm run lint` *(fails: `next lint --max-warnings 0` in web)*

------
https://chatgpt.com/codex/tasks/task_e_688cf57cc2488320ae4f4aff63623d60