### PR TITLE
feat: use GitHub App token for installation sync

### DIFF
--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -60,6 +60,16 @@ import * as Joi from 'joi';
           then: Joi.required(),
           otherwise: Joi.optional(),
         }),
+        GITHUB_APP_CLIENT_ID: Joi.string().when('NODE_ENV', {
+          is: 'production',
+          then: Joi.required(),
+          otherwise: Joi.optional(),
+        }),
+        GITHUB_APP_CLIENT_SECRET: Joi.string().when('NODE_ENV', {
+          is: 'production',
+          then: Joi.required(),
+          otherwise: Joi.optional(),
+        }),
         GITHUB_APP_PRIVATE_KEY: Joi.string().optional(),
         GITHUB_APP_PRIVATE_KEY_PATH: Joi.string().optional(),
         OPENAI_API_KEY: Joi.string().when('NODE_ENV', {

--- a/apps/api/src/linkedin/linkedin-publisher.service.spec.ts
+++ b/apps/api/src/linkedin/linkedin-publisher.service.spec.ts
@@ -5,6 +5,7 @@ import { getRepositoryToken } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { Post } from '../github/entities/post.entity';
 import { LinkedInApi } from './linkedin.api';
+import { UsersService } from '../users/users.service';
 
 describe('LinkedinPublisherService', () => {
   let service: LinkedinPublisherService;
@@ -14,6 +15,7 @@ describe('LinkedinPublisherService', () => {
   } as unknown as jest.Mocked<Repository<Post>>;
   const auth = { getToken: jest.fn() } as unknown as jest.Mocked<LinkedinAuthService>;
   const api = { createPost: jest.fn() } as jest.Mocked<LinkedInApi>;
+  const users = { findById: jest.fn() } as unknown as jest.Mocked<UsersService>;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -22,6 +24,7 @@ describe('LinkedinPublisherService', () => {
         { provide: getRepositoryToken(Post), useValue: repo },
         { provide: LinkedinAuthService, useValue: auth },
         { provide: 'LinkedInApi', useValue: api },
+        { provide: UsersService, useValue: users },
       ],
     }).compile();
     service = module.get(LinkedinPublisherService);
@@ -31,6 +34,7 @@ describe('LinkedinPublisherService', () => {
     repo.findOne.mockResolvedValue({ id: 1, postContent: 'hi', statusLinkedin: 'pending' } as any);
     auth.getToken.mockResolvedValue('tok');
     api.createPost.mockResolvedValue({ id: 'abc' });
+    users.findById.mockResolvedValue({ linkedInId: 'lid' } as any);
 
     await service.publish('u1', 1);
 


### PR DESCRIPTION
## Summary
- add GitHub App OAuth configuration
- exchange installation code for user-to-server token
- use GitHub App token when syncing installations

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688cf57deb588320a7a7c0f09d2f3fca