### PR TITLE
feat(api): handle github app callback

### DIFF
--- a/apps/api/src/linkedin/linkedin-publisher.service.spec.ts
+++ b/apps/api/src/linkedin/linkedin-publisher.service.spec.ts
@@ -5,6 +5,7 @@ import { getRepositoryToken } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { Post } from '../github/entities/post.entity';
 import { LinkedInApi } from './linkedin.api';
+import { UsersService } from '../users/users.service';
 
 describe('LinkedinPublisherService', () => {
   let service: LinkedinPublisherService;
@@ -14,6 +15,9 @@ describe('LinkedinPublisherService', () => {
   } as unknown as jest.Mocked<Repository<Post>>;
   const auth = { getToken: jest.fn() } as unknown as jest.Mocked<LinkedinAuthService>;
   const api = { createPost: jest.fn() } as jest.Mocked<LinkedInApi>;
+  const users = {
+    findById: jest.fn().mockResolvedValue({ linkedInId: 'ln1' }),
+  } as unknown as jest.Mocked<UsersService>;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -22,6 +26,7 @@ describe('LinkedinPublisherService', () => {
         { provide: getRepositoryToken(Post), useValue: repo },
         { provide: LinkedinAuthService, useValue: auth },
         { provide: 'LinkedInApi', useValue: api },
+        { provide: UsersService, useValue: users },
       ],
     }).compile();
     service = module.get(LinkedinPublisherService);


### PR DESCRIPTION
## Summary
- add `/api/github/callback` endpoint to handle GitHub App OAuth flow
- update LinkedIn publisher unit test to mock UsersService

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688cf58162b08320a953395feee95c2a