### PR TITLE
feat: admin dashboard with role-based user management

### DIFF
--- a/apps/api/src/auth/auth.service.ts
+++ b/apps/api/src/auth/auth.service.ts
@@ -9,6 +9,7 @@ export interface JwtPayload {
   sub: string;
   username: string;
   email: string;
+  role: string;
   iat?: number;
   exp?: number;
 }
@@ -66,6 +67,7 @@ export class AuthService {
       sub: user.id,
       username: user.username,
       email: user.email,
+      role: user.role,
     };
 
     return this.jwtService.sign(payload);

--- a/apps/api/src/auth/decorators/roles.decorator.ts
+++ b/apps/api/src/auth/decorators/roles.decorator.ts
@@ -1,0 +1,3 @@
+import { SetMetadata } from '@nestjs/common';
+
+export const Roles = (...roles: string[]) => SetMetadata('roles', roles);

--- a/apps/api/src/auth/guards/roles.guard.ts
+++ b/apps/api/src/auth/guards/roles.guard.ts
@@ -1,0 +1,21 @@
+import { Injectable, CanActivate, ExecutionContext } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { User } from '../../users/user.interface';
+
+@Injectable()
+export class RolesGuard implements CanActivate {
+  constructor(private reflector: Reflector) {}
+
+  canActivate(context: ExecutionContext): boolean {
+    const requiredRoles = this.reflector.getAllAndOverride<string[]>('roles', [
+      context.getHandler(),
+      context.getClass(),
+    ]);
+    if (!requiredRoles || requiredRoles.length === 0) {
+      return true;
+    }
+    const request = context.switchToHttp().getRequest();
+    const user = request.user as User | undefined;
+    return !!user && requiredRoles.includes(user.role);
+  }
+}

--- a/apps/api/src/users/user.entity.ts
+++ b/apps/api/src/users/user.entity.ts
@@ -27,6 +27,9 @@ export class UserEntity {
   @Column('text')
   name!: string;
 
+  @Column('text', { default: 'user' })
+  role!: string;
+
   @Column('text', { nullable: true })
   github_access_token?: string;
 

--- a/apps/api/src/users/user.interface.ts
+++ b/apps/api/src/users/user.interface.ts
@@ -1,3 +1,5 @@
+export type UserRole = 'user' | 'admin';
+
 export interface User {
   id: string;
   githubId: string;
@@ -5,6 +7,7 @@ export interface User {
   email: string;
   avatarUrl: string;
   name: string;
+  role: UserRole;
   linkedInId?: string;
   linkedinAccessToken?: string;
   githubAccessToken?: string;

--- a/apps/api/src/users/users.controller.ts
+++ b/apps/api/src/users/users.controller.ts
@@ -1,0 +1,39 @@
+import { Controller, Get, Delete, Param, UseGuards } from '@nestjs/common';
+import { UsersService } from './users.service';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { RolesGuard } from '../auth/guards/roles.guard';
+import { Roles } from '../auth/decorators/roles.decorator';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { ScheduledPost } from '../scheduled_posts/entities/scheduled_post.entity';
+
+@Controller('admin/users')
+@UseGuards(JwtAuthGuard, RolesGuard)
+@Roles('admin')
+export class UsersController {
+  constructor(
+    private readonly usersService: UsersService,
+    @InjectRepository(ScheduledPost)
+    private readonly scheduledPostsRepo: Repository<ScheduledPost>,
+  ) {}
+
+  @Get()
+  async findAll() {
+    const users = await this.usersService.findAll();
+    return Promise.all(
+      users.map(async (user) => {
+        const postsCount = await this.scheduledPostsRepo.count({
+          where: { user_id: user.id },
+        });
+        return { ...user, postsCount };
+      }),
+    );
+  }
+
+  @Delete(':id')
+  async remove(@Param('id') id: string) {
+    await this.usersService.delete(id);
+    await this.scheduledPostsRepo.delete({ user_id: id });
+    return { deleted: true };
+  }
+}

--- a/apps/api/src/users/users.module.ts
+++ b/apps/api/src/users/users.module.ts
@@ -2,10 +2,14 @@ import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { UsersService } from './users.service';
 import { UserEntity } from './user.entity';
+import { UsersController } from './users.controller';
+import { ScheduledPost } from '../scheduled_posts/entities/scheduled_post.entity';
+import { RolesGuard } from '../auth/guards/roles.guard';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([UserEntity])],
-  providers: [UsersService],
+  imports: [TypeOrmModule.forFeature([UserEntity, ScheduledPost])],
+  providers: [UsersService, RolesGuard],
   exports: [UsersService],
+  controllers: [UsersController],
 })
 export class UsersModule {}

--- a/apps/api/src/users/users.service.ts
+++ b/apps/api/src/users/users.service.ts
@@ -82,6 +82,7 @@ export class UsersService {
       email: githubProfile.emails?.[0]?.value || '',
       avatar_url: githubProfile.photos?.[0]?.value || '',
       name: githubProfile.displayName || githubProfile.username,
+      role: 'user',
       github_access_token: githubAccessToken
         ? this.encrypt(githubAccessToken)
         : undefined,
@@ -105,6 +106,7 @@ export class UsersService {
     if (updateData.email !== undefined) entity.email = updateData.email;
     if (updateData.avatarUrl !== undefined) entity.avatar_url = updateData.avatarUrl;
     if (updateData.name !== undefined) entity.name = updateData.name;
+    if (updateData.role !== undefined) entity.role = updateData.role;
     if (updateData.linkedInId !== undefined) entity.linkedIn_id = updateData.linkedInId;
     if (updateData.githubAccessToken !== undefined) {
       entity.github_access_token = this.encrypt(updateData.githubAccessToken);
@@ -135,6 +137,15 @@ export class UsersService {
     );
   }
 
+  async findAll(): Promise<User[]> {
+    const entities = await this.repo.find();
+    return entities.map((e) => this.toUser(e));
+  }
+
+  async delete(id: string): Promise<void> {
+    await this.repo.delete({ id });
+  }
+
   private toUser(entity: UserEntity): User {
     return {
       id: entity.id,
@@ -143,6 +154,7 @@ export class UsersService {
       email: entity.email,
       avatarUrl: entity.avatar_url,
       name: entity.name,
+      role: entity.role,
       linkedInId: entity.linkedIn_id,
       linkedinAccessToken: entity.linkedin_access_token
         ? this.decrypt(entity.linkedin_access_token)

--- a/apps/web/app/(protected)/admin/users/page.tsx
+++ b/apps/web/app/(protected)/admin/users/page.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import ProtectedRoute from "@/components/auth/ProtectedRoute";
+import { useAuthenticatedQuery, authenticatedFetcher } from "@/hooks/useAuthenticatedQuery";
+import { Button } from "@/components/ui/button";
+import { User } from "@/types/user";
+
+interface AdminUser extends User {
+  postsCount: number;
+}
+
+export default function AdminUsersPage() {
+  return (
+    <ProtectedRoute requiredRole="admin">
+      <AdminUsersContent />
+    </ProtectedRoute>
+  );
+}
+
+function AdminUsersContent() {
+  const { data, refetch } = useAuthenticatedQuery<AdminUser[]>(
+    ["admin-users"],
+    "/admin/users"
+  );
+
+  const handleDelete = async (id: string) => {
+    await authenticatedFetcher(`/admin/users/${id}`, { method: "DELETE" });
+    refetch();
+  };
+
+  if (!data) {
+    return <div className="p-4">Chargement...</div>;
+  }
+
+  return (
+    <div className="p-4">
+      <h1 className="text-2xl font-bold mb-4">Gestion des utilisateurs</h1>
+      <table className="min-w-full divide-y divide-gray-200">
+        <thead>
+          <tr>
+            <th className="px-4 py-2 text-left">Utilisateur</th>
+            <th className="px-4 py-2 text-left">Email</th>
+            <th className="px-4 py-2 text-left">Posts</th>
+            <th className="px-4 py-2"></th>
+          </tr>
+        </thead>
+        <tbody>
+          {data.map((u) => (
+            <tr key={u.id} className="border-b">
+              <td className="px-4 py-2">{u.username}</td>
+              <td className="px-4 py-2">{u.email}</td>
+              <td className="px-4 py-2">{u.postsCount}</td>
+              <td className="px-4 py-2 text-right">
+                <Button
+                  variant="destructive"
+                  size="sm"
+                  onClick={() => handleDelete(u.id)}
+                >
+                  Supprimer
+                </Button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/apps/web/components/auth/ProtectedRoute.tsx
+++ b/apps/web/components/auth/ProtectedRoute.tsx
@@ -9,21 +9,29 @@ interface ProtectedRouteProps {
   children: React.ReactNode;
   fallback?: React.ReactNode;
   redirectTo?: string;
+  requiredRole?: string;
 }
 
 export default function ProtectedRoute({
   children,
   fallback,
   redirectTo = "/auth/login",
+  requiredRole,
 }: ProtectedRouteProps) {
-  const { status } = useSession();
+  const { status, data: session } = useSession();
   const router = useRouter();
 
   useEffect(() => {
     if (status === "unauthenticated") {
       router.push(redirectTo);
+    } else if (
+      status === "authenticated" &&
+      requiredRole &&
+      session?.user.role !== requiredRole
+    ) {
+      router.push("/");
     }
-  }, [status, router, redirectTo]);
+  }, [status, router, redirectTo, requiredRole, session?.user.role]);
 
   if (status === "loading") {
     return (
@@ -39,7 +47,10 @@ export default function ProtectedRoute({
     );
   }
 
-  if (status !== "authenticated") {
+  if (
+    status !== "authenticated" ||
+    (requiredRole && session?.user.role !== requiredRole)
+  ) {
     return null;
   }
 

--- a/apps/web/hooks/useSidebarItems.ts
+++ b/apps/web/hooks/useSidebarItems.ts
@@ -1,6 +1,7 @@
 import { useMemo } from "react";
 import { SidebarItem } from "@/components/layout/Sidebar";
 import { useSidebarBadgeData } from "@/hooks/useSidebarBadgeData";
+import { useSession } from "next-auth/react";
 import {
   LayoutDashboard,
   GitBranch,
@@ -17,14 +18,17 @@ import {
   Clock,
   Send,
   Archive,
+  Shield,
 } from "lucide-react";
 
 export function useSidebarItems(): SidebarItem[] {
   const badgeData = useSidebarBadgeData();
+  const { data: session } = useSession();
 
   return useMemo(
-    () => [
-      { title: "Dashboard", href: "/dashboard", icon: LayoutDashboard },
+    () => {
+      const items: SidebarItem[] = [
+        { title: "Dashboard", href: "/dashboard", icon: LayoutDashboard },
       {
         title: "Dépôts",
         href: "/repositories",
@@ -86,7 +90,16 @@ export function useSidebarItems(): SidebarItem[] {
       },
       { title: "Paramètres", href: "/settings", icon: Settings },
       { title: "Aide & Support", href: "/help", icon: HelpCircle },
-    ],
-    [badgeData]
+    ];
+      if (session?.user.role === "admin") {
+        items.splice(1, 0, {
+          title: "Administration",
+          href: "/admin/users",
+          icon: Shield,
+        });
+      }
+      return items;
+    },
+    [badgeData, session?.user.role]
   );
 }

--- a/apps/web/lib/auth.ts
+++ b/apps/web/lib/auth.ts
@@ -59,6 +59,7 @@ interface SyncResponse {
     email: string;
     avatarUrl: string;
     name: string;
+    role: string;
     linkedInId?: string;
     linkedinAccessToken?: string;
     createdAt: string;
@@ -173,6 +174,7 @@ export const authOptions: NextAuthConfig = {
           username: u.username,
           githubId: u.githubId,
           avatarUrl: u.avatarUrl,
+          role: u.role,
           linkedInId: u.linkedInId,
           linkedinAccessToken: u.linkedinAccessToken,
           createdAt: u.createdAt,

--- a/apps/web/types/next-auth.d.ts
+++ b/apps/web/types/next-auth.d.ts
@@ -12,6 +12,7 @@ declare module "next-auth" {
       githubId?: string;
       username?: string;
       avatarUrl?: string;
+      role?: string;
       linkedInId?: string;
       linkedinAccessToken?: string;
       createdAt?: string;
@@ -26,6 +27,7 @@ declare module "next-auth" {
     email: string;
     avatarUrl: string;
     name: string;
+    role: string;
     linkedInId?: string;
     linkedinAccessToken?: string;
     createdAt: string;
@@ -43,6 +45,7 @@ declare module "next-auth/jwt" {
       email: string;
       avatarUrl: string;
       name: string;
+      role: string;
       linkedInId?: string;
       linkedinAccessToken?: string;
       createdAt: string;

--- a/apps/web/types/user.ts
+++ b/apps/web/types/user.ts
@@ -5,6 +5,7 @@ export interface User {
   email: string;
   avatarUrl: string;
   name: string;
+  role: string;
   linkedInId?: string;
   linkedinAccessToken?: string;
   createdAt: string;

--- a/apps/web/utils/routes.ts
+++ b/apps/web/utils/routes.ts
@@ -5,6 +5,7 @@ export const publicRoutes = ["/", "/auth/callback", "/auth/error", "/api/auth"];
 export const protectedRoutes = [
   "/dashboard",
   "/repositories",
+  "/admin",
   "/api/protected",
 ];
 


### PR DESCRIPTION
## Summary
- add role field to users and JWT payload
- protect new admin user management endpoints with role guard
- build admin dashboard in Next.js for viewing and removing users

## Testing
- `npm test` *(fails: Lifecycle script `test` failed with error)*


------
https://chatgpt.com/codex/tasks/task_e_688dd1f4ec648320804ddeb6132d1890