### PR TITLE
feat: generate repository post

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,8 @@ GITHUB_WEBHOOK_SECRET="your_webhook_secret"
 
 # OpenAI
 OPENAI_API_KEY="sk-..."
+GENERATE_PROMPT="..."
+GENERATE_REPOSITORY_PROMPT="..."
 
 # Sessions & Encryption
 SESSION_SECRET="your-session-secret-key"

--- a/apps/api/prompts/repository.prompt
+++ b/apps/api/prompts/repository.prompt
@@ -1,0 +1,42 @@
+# System
+Tu es un expert en création de contenu LinkedIn pour développeurs, avec un œil marketing et design. Tes posts doivent :
+- Captiver dès la première ligne (hook fort)
+- Mettre en valeur les caractéristiques du repository et l'intérêt pour la communauté
+- Apporter une vraie leçon/apprentissage
+- Inviter à l’échange avec une question ou call-to-action
+- Rester professionnel, crédible et optimisé pour l’algorithme LinkedIn (paragraphes courts, listes à puces, hashtags pertinents, ton adapté)
+
+# User
+Contexte :
+- Dépôt : {{repoFullName}}
+- Description : {{description}}
+- Stars : {{stars}}
+- Forks : {{forks}}
+- Issues ouvertes : {{issues}}
+- Langage principal : {{language}}
+- Topics : {{topics}}
+- Date : {{timestamp}}
+
+Consignes :
+1. **Résumé** (champ "summary") : 2–3 phrases très claires qui présentent le projet et son intérêt.
+2. **Post complet** (champ "post") :
+   - **Hook** : 1 phrase d’accroche percutante.
+   - **Contexte** : 1 phrase de présentation du repository.
+   - **Détails** : 2–3 bullets mettant en avant des chiffres clés ou fonctionnalités.
+   - **Leçon** : insight ou apprentissage en 1 phrase.
+   - **Call-to-action** : invitation à commenter ou explorer le repo.
+   - **Hashtags** : 3 à 5 mots-clés pertinents.
+
+Langue : {{lang}}
+Ton : {{tone}}
+Sortie attendue : {{outputs}}
+
+IMPORTANT :
+– Réponds **uniquement** par un JSON valide, sans explication supplémentaire.
+– Format exact :
+```json
+{
+  "summary": "…",
+  "post": "…"
+}
+```

--- a/apps/api/src/github/dto/generate-repository.dto.ts
+++ b/apps/api/src/github/dto/generate-repository.dto.ts
@@ -1,0 +1,50 @@
+import {
+  IsString,
+  IsNumber,
+  IsOptional,
+  IsArray,
+  ValidateNested,
+  IsDateString,
+} from 'class-validator';
+import { Type } from 'class-transformer';
+import { GenerateOptionsDto } from './generate.dto';
+
+export class RepositoryInfoDto {
+  @IsString()
+  fullName!: string;
+
+  @IsOptional()
+  @IsString()
+  description?: string;
+
+  @IsNumber()
+  stars!: number;
+
+  @IsNumber()
+  forks!: number;
+
+  @IsNumber()
+  openIssues!: number;
+
+  @IsOptional()
+  @IsString()
+  language?: string;
+
+  @IsArray()
+  @IsString({ each: true })
+  topics!: string[];
+
+  @IsDateString()
+  timestamp!: string;
+}
+
+export class GenerateRepositoryDto {
+  @ValidateNested()
+  @Type(() => RepositoryInfoDto)
+  repository!: RepositoryInfoDto;
+
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => GenerateOptionsDto)
+  options?: GenerateOptionsDto;
+}

--- a/apps/api/src/github/github.controller.ts
+++ b/apps/api/src/github/github.controller.ts
@@ -29,6 +29,7 @@ import { JwtService } from '@nestjs/jwt';
 import { ConfigService } from '@nestjs/config';
 import { DEFAULT_JWT_SECRET } from '../common/constants';
 import { GenerateDto, GenerateResultDto } from './dto/generate.dto';
+import { GenerateRepositoryDto } from './dto/generate-repository.dto';
 import { PostFeedbackDto, UpdatePostStatusDto } from './dto/post.dto';
 import { Event } from './entities/event.entity';
 import { Repository } from 'typeorm';
@@ -302,6 +303,18 @@ export class GithubController {
       owner,
       repo,
     );
+  }
+
+  @UseGuards(JwtAuthGuard)
+  @Post('repositories/:owner/:repo/generate')
+  async generateRepositoryPost(
+    @Request() req: AuthenticatedRequest,
+    @Param('owner') owner: string,
+    @Param('repo') repo: string,
+    @Body() body: GenerateRepositoryDto,
+  ): Promise<GenerateResultDto> {
+    const user = req.user;
+    return this.generateService.generateFromRepository(user.id, body);
   }
 
   @UseGuards(JwtAuthGuard)

--- a/apps/api/src/github/services/generate.service.ts
+++ b/apps/api/src/github/services/generate.service.ts
@@ -8,6 +8,7 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { OpenAI } from 'openai';
 import { GenerateDto, GenerateResultDto } from '../dto/generate.dto';
+import { GenerateRepositoryDto } from '../dto/generate-repository.dto';
 import { Post } from '../entities/post.entity';
 import { Installation } from '../entities/installation.entity';
 import { Event } from '../entities/event.entity';
@@ -25,6 +26,7 @@ interface QuotaInfo {
 export class GenerateService {
   private openai: OpenAI;
   private promptTemplate: string;
+  private repositoryPromptTemplate: string;
   private quotas = new Map<string, QuotaInfo>();
 
   constructor(
@@ -51,7 +53,16 @@ export class GenerateService {
     ).trim();
     if (!this.promptTemplate) {
       throw new Error(
-        'GENERATE_PROMPT environment variable is missing or empty',
+      'GENERATE_PROMPT environment variable is missing or empty',
+      );
+    }
+
+    this.repositoryPromptTemplate = (
+      this.config.get<string>('GENERATE_REPOSITORY_PROMPT') ?? ''
+    ).trim();
+    if (!this.repositoryPromptTemplate) {
+      throw new Error(
+        'GENERATE_REPOSITORY_PROMPT environment variable is missing or empty',
       );
     }
   }
@@ -91,6 +102,28 @@ export class GenerateService {
       .replace(/\{\{desc\}\}/g, event.desc)
       .replace(/\{\{filesChanged\}\}/g, event.filesChanged.join(', '))
       .replace(/\{\{statsBlock\}\}/g, statsBlock)
+      .replace(/\{\{lang\}\}/g, lang)
+      .replace(/\{\{tone\}\}/g, tone)
+      .replace(/\{\{outputs\}\}/g, outputs);
+  }
+
+  private buildRepositoryPrompt(dto: GenerateRepositoryDto): string {
+    const { repository, options } = dto;
+    const lang = options?.lang ?? 'français';
+    const tone = options?.tone ?? 'accessible, professionnel, léger humour';
+    const outputs = options?.output?.join(', ') ?? 'summary, post';
+
+    const topics = repository.topics.join(', ');
+
+    return this.repositoryPromptTemplate
+      .replace(/\{\{repoFullName\}\}/g, repository.fullName)
+      .replace(/\{\{description\}\}/g, repository.description || '')
+      .replace(/\{\{stars\}\}/g, String(repository.stars))
+      .replace(/\{\{forks\}\}/g, String(repository.forks))
+      .replace(/\{\{issues\}\}/g, String(repository.openIssues))
+      .replace(/\{\{language\}\}/g, repository.language || '')
+      .replace(/\{\{topics\}\}/g, topics)
+      .replace(/\{\{timestamp\}\}/g, repository.timestamp)
       .replace(/\{\{lang\}\}/g, lang)
       .replace(/\{\{tone\}\}/g, tone)
       .replace(/\{\{outputs\}\}/g, outputs);
@@ -272,6 +305,39 @@ export class GenerateService {
       return parsed;
     } catch (e) {
       console.error('Error in generate service:', e);
+      if (e instanceof BadRequestException) throw e;
+      throw new BadRequestException(
+        `Failed to parse OpenAI response: ${(e as Error).message}`,
+      );
+    }
+  }
+
+  async generateFromRepository(
+    userId: string,
+    dto: GenerateRepositoryDto,
+  ): Promise<GenerateResultDto> {
+    this.checkQuota(userId);
+
+    const prompt = this.buildRepositoryPrompt(dto);
+
+    try {
+      const res = await this.openai.chat.completions.create({
+        model: 'gpt-4o-mini',
+        messages: [{ role: 'user', content: prompt }],
+        temperature: 0.7,
+      });
+
+      const content = res.choices[0]?.message?.content;
+      if (!content) {
+        throw new BadRequestException('No content received from OpenAI');
+      }
+
+      const cleaned = this.cleanJsonResponse(content);
+      const parsed = this.validateGenerateResult(JSON.parse(cleaned));
+
+      return parsed;
+    } catch (e) {
+      console.error('Error in generateFromRepository:', e);
       if (e instanceof BadRequestException) throw e;
       throw new BadRequestException(
         `Failed to parse OpenAI response: ${(e as Error).message}`,

--- a/apps/web/app/(protected)/repositories/[id]/page.tsx
+++ b/apps/web/app/(protected)/repositories/[id]/page.tsx
@@ -13,6 +13,10 @@ import { Button } from "@/components/ui/button";
 import { ArrowLeft, ExternalLink, Loader2 } from "lucide-react";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import Link from "next/link";
+import {
+  useGenerateRepositoryPost,
+  createRepositoryPostRequest,
+} from "@/hooks/useGenerateRepositoryPost";
 
 export default function RepositoryDetailPage({
   params,
@@ -24,9 +28,9 @@ export default function RepositoryDetailPage({
   const initialInstallationId = searchParams.get("installationId");
 
   // State pour gérer l'installation sélectionnée
-  const [selectedInstallationId, setSelectedInstallationId] = useState<
-    string | null
-  >(initialInstallationId);
+  const [selectedInstallationId] = useState<string | null>(
+    initialInstallationId
+  );
 
   // Décoder l'ID qui est au format owner/repo
   const [owner, repo] = decodeURIComponent(id).split("/");
@@ -35,22 +39,9 @@ export default function RepositoryDetailPage({
     data: repositoryDetails,
     isLoading,
     error,
-    refetch,
   } = useRepositoryDetails(owner, repo, selectedInstallationId || undefined);
 
-  // Gérer le changement d'installation
-  const handleInstallationChange = (installationId: string | null) => {
-    setSelectedInstallationId(installationId);
-    const url = new URL(window.location.href);
-    if (installationId) {
-      url.searchParams.set("installationId", installationId);
-    } else {
-      url.searchParams.delete("installationId");
-    }
-    window.history.replaceState({}, "", url.toString());
-
-    refetch();
-  };
+  const generatePost = useGenerateRepositoryPost(owner, repo);
 
   if (isLoading) {
     return (
@@ -105,25 +96,40 @@ export default function RepositoryDetailPage({
   return (
     <div className="space-y-6">
       {/* Header avec navigation */}
-      <div className="flex items-center justify-between">
-        <Link href="/repositories">
-          <Button variant="ghost" size="sm">
-            <ArrowLeft className="h-4 w-4 mr-2" />
-            Retour aux repositories
-          </Button>
-        </Link>
-        <Button asChild>
-          <a
-            href={repositoryDetails.repository.html_url}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="flex items-center space-x-2"
-          >
-            <ExternalLink className="h-4 w-4" />
-            <span>Voir sur GitHub</span>
-          </a>
-        </Button>
-      </div>
+        <div className="flex items-center justify-between">
+          <Link href="/repositories">
+            <Button variant="ghost" size="sm">
+              <ArrowLeft className="h-4 w-4 mr-2" />
+              Retour aux repositories
+            </Button>
+          </Link>
+          <div className="flex space-x-2">
+            <Button
+              onClick={() =>
+                generatePost.mutate(
+                  createRepositoryPostRequest(repositoryDetails)
+                )
+              }
+              disabled={generatePost.isPending}
+            >
+              {generatePost.isPending && (
+                <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+              )}
+              Générer un post
+            </Button>
+            <Button asChild>
+              <a
+                href={repositoryDetails.repository.html_url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="flex items-center space-x-2"
+              >
+                <ExternalLink className="h-4 w-4" />
+                <span>Voir sur GitHub</span>
+              </a>
+            </Button>
+          </div>
+        </div>
 
       {/* Sélecteur d'installation */}
       {/* <InstallationSelector
@@ -133,7 +139,23 @@ export default function RepositoryDetailPage({
       /> */}
 
       {/* Vue d'ensemble */}
-      <RepositoryOverview data={repositoryDetails} />
+        <RepositoryOverview data={repositoryDetails} />
+
+        {generatePost.isSuccess && generatePost.data && (
+          <div className="space-y-2 p-4 border rounded">
+            <h3 className="font-semibold">Résumé</h3>
+            <p>{generatePost.data.summary}</p>
+            <h3 className="font-semibold">Post</h3>
+            <p>{generatePost.data.post}</p>
+          </div>
+        )}
+        {generatePost.isError && (
+          <Alert variant="destructive">
+            <AlertDescription>
+              {generatePost.error.message}
+            </AlertDescription>
+          </Alert>
+        )}
 
       {/* Grille de contenu */}
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">

--- a/apps/web/hooks/useGenerateRepositoryPost.ts
+++ b/apps/web/hooks/useGenerateRepositoryPost.ts
@@ -1,0 +1,55 @@
+import { useMutation } from "@tanstack/react-query";
+import { authenticatedFetcher } from "./useAuthenticatedQuery";
+import { RepositoryDetails } from "@/types/repository-details";
+
+interface RepositoryPostRequest {
+  repository: {
+    fullName: string;
+    description?: string | null;
+    stars: number;
+    forks: number;
+    openIssues: number;
+    language?: string | null;
+    topics: string[];
+    timestamp: string;
+  };
+  options?: {
+    lang?: string;
+    tone?: string;
+    output?: string[];
+  };
+}
+
+interface GeneratePostResponse {
+  summary: string;
+  post: string;
+}
+
+export function useGenerateRepositoryPost(owner: string, repo: string) {
+  return useMutation<GeneratePostResponse, Error, RepositoryPostRequest>({
+    mutationFn: async request => {
+      const url = `/github/repositories/${owner}/${repo}/generate`;
+      return authenticatedFetcher<GeneratePostResponse>(url, {
+        method: "POST",
+        body: JSON.stringify(request),
+      });
+    },
+  });
+}
+
+export function createRepositoryPostRequest(
+  details: RepositoryDetails
+): RepositoryPostRequest {
+  return {
+    repository: {
+      fullName: details.repository.full_name,
+      description: details.repository.description,
+      stars: details.repository.stargazers_count,
+      forks: details.repository.forks_count,
+      openIssues: details.repository.open_issues_count,
+      language: details.repository.language,
+      topics: details.repository.topics,
+      timestamp: new Date().toISOString(),
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- add backend endpoint and service to generate LinkedIn posts from repository metadata using new `GENERATE_REPOSITORY_PROMPT`
- expose new React hook and UI button on repository detail page to trigger generation
- document new env vars and provide repository prompt template

## Testing
- `npm test`
- `npm run lint` *(fails: react/no-unescaped-entities and other existing warnings)*

------
https://chatgpt.com/codex/tasks/task_e_6891c99d6f60832094f303076ec4570b